### PR TITLE
Add dotnet outdated

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -1,8 +1,14 @@
 name: update-dotnet-sdk
 
+env:
+  GIT_COMMIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+  GIT_COMMIT_USER_NAME: github-actions[bot]
+  TERM: xterm
+
 on:
   schedule:
-    - cron:  '0 */6 * * *'
+    - cron:  '30 09 * * MON-FRI'
+    - cron:  '00 19 * * TUE'
   workflow_dispatch:
 
 jobs:
@@ -15,8 +21,93 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Update .NET SDK
+      id: update-dotnet-sdk
       uses: martincostello/update-dotnet-sdk@v2
       with:
+        labels: "dependencies,.NET"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+        user-email: ${{ env.GIT_COMMIT_USER_EMAIL }}
+        user-name: ${{ env.GIT_COMMIT_USER_NAME }}
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v3
+      if : ${{ steps.update-dotnet-sdk.outputs.sdk-updated == 'true' }}
+
+    - name: Update NuGet packages
+      if : ${{ steps.update-dotnet-sdk.outputs.sdk-updated == 'true' }}
+      shell: pwsh
+      env:
+        DOTNET_CLI_TELEMETRY_OPTOUT: true
+        DOTNET_NOLOGO: true
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+        NUGET_XMLDOC_MODE: skip
+      run: |
+        $ErrorActionPreference = "Stop"
+
+        dotnet tool install --global dotnet-outdated-tool
+
+        $tempPath = [System.IO.Path]::GetTempPath()
+        $updatesPath = (Join-Path $tempPath "dotnet-outdated.json")
+
+        Write-Host "Checking for .NET NuGet package(s) to update..."
+
+        dotnet outdated `
+          --upgrade `
+          --version-lock Major `
+          --output $updatesPath `
+          --include "Microsoft.AspNetCore." `
+          --include "Microsoft.NET.Test.Sdk"
+
+        $dependencies = @()
+
+        if (Test-Path $updatesPath) {
+          $dependencies = `
+            Get-Content -Path $updatesPath | `
+            ConvertFrom-Json | `
+            Select-Object -ExpandProperty projects | `
+            Select-Object -ExpandProperty TargetFrameworks | `
+            Select-Object -ExpandProperty Dependencies | `
+            Sort-Object -Property Name -Unique
+        }
+
+        if ($dependencies.Count -gt 0) {
+          Write-Host "Found $($dependencies.Count) .NET NuGet package(s) to update." -ForegroundColor Green
+
+          $commitMessageLines = @(
+            "Update .NET NuGet packages",
+            "",
+            "Update .NET dependencies to their latest versions for the .NET ${{ steps.update-dotnet-sdk.outputs.sdk-version }} SDK.",
+            "",
+            "---",
+            "updated-dependencies:"
+          )
+
+          foreach ($dependency in $dependencies) {
+            $commitMessageLines += "- dependency-name: $($dependency.Name)"
+            $commitMessageLines += "  dependency-type: direct:production"
+            $commitMessageLines += "  update-type: version-update:semver-$($dependency.UpgradeSeverity.ToLowerInvariant())"
+          }
+
+          $commitMessageLines += "..."
+          $commitMessageLines += ""
+          $commitMessageLines += ""
+
+          $commitMessage = $commitMessageLines -join "`n"
+
+          git config user.email "${{ env.GIT_COMMIT_USER_EMAIL }}"
+          git config user.name "${{ env.GIT_COMMIT_USER_NAME }}"
+
+          git add .
+          git commit -m $commitMessage
+          git push
+
+          Write-Host "Pushed update to $($dependencies.Count) NuGet package(s)." -ForegroundColor Green
+        }
+        else {
+          Write-Host "There are no .NET NuGet packages to update." -ForegroundColor Green
+        }


### PR DESCRIPTION
- Add `dotnet-outdated-tool` to also update .NET NuGet packages, if there are any relevant updates, when the .NET SDK is updated.
- Change the update schedule to be less frequent.
