### PR TITLE
PR automation and repo/workflow-hardening

### DIFF
--- a/.github/workflows/approve-and-merge.yml
+++ b/.github/workflows/approve-and-merge.yml
@@ -1,0 +1,160 @@
+name: approve-and-merge
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  REVIEWER_LOGIN: ${{ vars.REVIEWER_USER_NAME }}
+
+permissions:
+  contents: read
+
+jobs:
+  review-pull-request:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == vars.UPDATER_COMMIT_USER_NAME }}
+
+    steps:
+
+    - name: Generate GitHub application token
+      id: generate-application-token
+      uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
+      with:
+        application_id: ${{ secrets.REVIEWER_APPLICATION_ID }}
+        application_private_key: ${{ secrets.REVIEWER_APPLICATION_PRIVATE_KEY }}
+        permissions: "contents:write, pull_requests:write"
+
+    - name: Install powershell-yaml
+      shell: pwsh
+      run: Install-Module -Name powershell-yaml -Force -MaximumVersion "0.4.7"
+
+    - name: Check which dependencies were updated
+      id: check-dependencies
+      env:
+        # This list of trusted package prefixes needs to stay in sync with include-nuget-packages in the update-dotnet-sdk workflow.
+        INCLUDE_NUGET_PACKAGES: "Microsoft.AspNetCore.,Microsoft.NET.Test.Sdk"
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+      shell: pwsh
+      run: |
+        # Replicate the logic in the dependabot/fetch-metadata action.
+        # See https://github.com/dependabot/fetch-metadata/blob/aea2135c95039f05c64436f1d14638c300e10b2b/src/dependabot/update_metadata.ts#L29-L68.
+        # Query the GitHub API to get the commits in the pull request.
+        $commits = gh api `
+          /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits `
+          --jq '.[] | { author: .author.login, message: .commit.message }' | ConvertFrom-Json
+
+        # We should only approve pull requests that only contain commits from
+        # the GitHub user we expected and only commits that contain the metadata
+        # we need to determine what dependencies were updated by the other workflow.
+        $expectedUser = "${{ vars.UPDATER_COMMIT_USER_NAME }}"
+        $onlyDependencyUpdates = $True
+        $onlyChangesFromUser = $True
+
+        $dependencies = @()
+
+        foreach ($commit in $commits) {
+          if ($commit.Author -ne $expectedUser) {
+            # Some other commit is in the pull request
+            $onlyChangesFromUser = $False
+          }
+          # Extract the YAML metadata block from the commit message.
+          $match = [Regex]::Match($commit.Message, '(?m)^-{3}\s(?<dependencies>[\S|\s]*?)\s^\.{3}$')
+          if ($match.Success -eq $True) {
+            # Extract the names and update type from each dependency.
+            $metadata = ($match.Value | ConvertFrom-Yaml -Ordered)
+            $updates = $metadata["updated-dependencies"]
+            if ($updates) {
+              foreach ($update in $updates) {
+                $dependencies += @{
+                  Name = $update['dependency-name'];
+                  Type = $update['update-type'];
+                }
+              }
+            }
+          }
+          else {
+            # The pull request contains a commit that we didn't expect as the metadata is missing.
+            $onlyDependencyUpdates = $False
+          }
+        }
+
+        # Did we find at least one dependency?
+        $isPatch = $dependencies.Length -gt 0
+        $onlyTrusted = $dependencies.Length -gt 0
+        $trustedPackages = $env:INCLUDE_NUGET_PACKAGES.Split(',')
+
+        foreach ($dependency in $dependencies) {
+          $isPatch = $isPatch -And $dependency.Type -eq "version-update:semver-patch"
+          $onlyTrusted = $onlyTrusted -And
+            (
+              ($dependency.Name -eq "Microsoft.NET.Sdk") -Or
+              (($trustedPackages | Where-Object { $dependency.Name.StartsWith($_) }).Count -gt 0)
+            )
+        }
+
+        # We only trust the pull request to approve and auto-merge it
+        # if it only contains commits which change the .NET SDK and
+        # Microsoft-published NuGet packages that were made by the GitHub
+        # login we expect to make those changes in the other workflow.
+        $isTrusted = (($onlyTrusted -And $isPatch) -And $onlyChangesFromUser) -And $onlyDependencyUpdates
+        "is-trusted-update=$isTrusted" >> $env:GITHUB_OUTPUT
+
+    - name: Checkout code
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      # As long as it's not already approved, approve the pull request and enable auto-merge.
+      # Our CI tests coupled with required statuses should ensure that the changes compile
+      # and that the application is still functional after the update; any bug that might be
+      # introduced by the update should be caught by the tests. If that happens, the build
+      # workflow will fail and the preconditions for the auto-merge to happen won't be met.
+    - name: Approve pull request and enable auto-merge
+      if: ${{ steps.check-dependencies.outputs.is-trusted-update == 'true' }}
+      env:
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      shell: pwsh
+      run: |
+        $approvals = gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews | ConvertFrom-Json
+        $approvals = $approvals | Where-Object { $_.user.login -eq $env:REVIEWER_LOGIN }
+        $approvals = $approvals | Where-Object { $_.state -eq "APPROVED" }
+
+        if ($approvals.Length -eq 0) {
+          gh pr checkout "$env:PR_URL"
+          gh pr review --approve "$env:PR_URL"
+          gh pr merge --auto --squash "$env:PR_URL"
+        }
+        else {
+          Write-Host "PR already approved.";
+        }
+
+    # If something was present in the pull request that isn't expected, then disable
+    # auto-merge so that a human is required to look at the pull request and make a
+    # decision to merge it or not. This is to prevent the pull request from being merged
+    # automatically if there's an unexpected change introduced. Any existing review
+    # approvals that were made by the bot are also dismissed so human approval is required.
+    - name: Disable auto-merge and dismiss approvals
+      if: ${{ steps.check-dependencies.outputs.is-trusted-update != 'true' }}
+      env:
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      shell: pwsh
+      run: |
+        $approvals = gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews | ConvertFrom-Json
+        $approvals = $approvals | Where-Object { $_.user.login -eq $env:REVIEWER_LOGIN }
+        $approvals = $approvals | Where-Object { $_.state -eq "APPROVED" }
+
+        if ($approvals.Length -gt 0) {
+          gh pr checkout "$env:PR_URL"
+          gh pr merge --disable-auto "$env:PR_URL"
+          foreach ($approval in $approvals) {
+            gh api `
+              --method PUT `
+              /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/$($approval.id)/dismissals `
+              -f message='Cannot approve as other changes have been introduced.' `
+              -f event='DISMISS'
+          }
+        }
+        else {
+          Write-Host "PR not already approved.";
+        }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: read
-  packages: write
+  packages: read
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -39,12 +39,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           fetch-depth: 0
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
+      - name: Setup NuGet cache
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
+          restore-keys: ${{ runner.os }}-nuget-
 
       - name: Build, Test and Package
         if: ${{ runner.os != 'linux' }}
@@ -56,22 +63,84 @@ jobs:
         shell: pwsh
         run: ./build.ps1 -EnableIntegrationTests
 
-      - uses: codecov/codecov-action@v3
-        name: Upload coverage to Codecov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2 # v3.1.3
         with:
           file: ./artifacts/coverage.cobertura.xml
           flags: ${{ matrix.os_name }}
 
       - name: Publish NuGet packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: packages-${{ matrix.os_name }}
           path: ./artifacts/packages
 
-      - name: Publish pre-release NuGet packages to GitHub Packages
-        run: dotnet nuget push "artifacts\packages\*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols --source https://nuget.pkg.github.com/justeattakeaway/index.json
-        if: ${{ github.event.repository.fork == false && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && runner.os == 'Windows' }}
+  validate-packages:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
 
-      - name: Push NuGet packages to NuGet.org
-        run: dotnet nuget push "artifacts\packages\*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json
-        if: ${{ github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v') && runner.os == 'Windows' }}
+    - name: Download packages
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: packages-windows
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
+    - name: Validate NuGet packages
+      shell: pwsh
+      run: |
+        dotnet tool install --global dotnet-validate --version 0.0.1-preview.304
+        $packages = Get-ChildItem -Filter "*.nupkg" | ForEach-Object { $_.FullName }
+        $invalidPackages = 0
+        foreach ($package in $packages) {
+          dotnet validate package local $package
+          if ($LASTEXITCODE -ne 0) {
+            $invalidPackages++
+          }
+        }
+        if ($invalidPackages -gt 0) {
+          Write-Output "::error::$invalidPackages NuGet package(s) failed validation."
+        }
+
+  publish-github:
+    needs: validate-packages
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+    if: |
+      github.event.repository.fork == false &&
+      (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
+       startsWith(github.ref, 'refs/tags/v'))
+    steps:
+
+    - name: Download packages
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: packages-windows
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
+    - name: Publish NuGet packages to GitHub Packages
+      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+
+  publish-nuget:
+    needs: validate-packages
+    runs-on: ubuntu-latest
+    if: |
+      github.event.repository.fork == false &&
+      startsWith(github.ref, 'refs/tags/v')
+    steps:
+
+    - name: Download packages
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: packages-windows
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
+    - name: Push NuGet packages to NuGet.org
+      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -1,0 +1,53 @@
+name: code-ql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * MON'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  code-ql:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
+    - name: Setup NuGet cache
+      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
+        restore-keys: ${{ runner.os }}-nuget-
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@b2c19fb9a2a485599ccf4ed5d65527d94bc57226 # v2.3.0
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@b2c19fb9a2a485599ccf4ed5d65527d94bc57226 # v2.3.0
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@b2c19fb9a2a485599ccf4ed5d65527d94bc57226 # v2.3.0
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -1,0 +1,48 @@
+name: dependabot-approve
+
+on: pull_request_target
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+
+    steps:
+
+      - name: Get dependabot metadata
+        uses: dependabot/fetch-metadata@efb5c8deb113433243b6b08de1aa879d5aa01cf7 # v1.4.0
+        id: dependabot-metadata
+
+      - name: Generate GitHub application token
+        id: generate-application-token
+        uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
+        with:
+          application_id: ${{ secrets.REVIEWER_APPLICATION_ID }}
+          application_private_key: ${{ secrets.REVIEWER_APPLICATION_PRIVATE_KEY }}
+          permissions: "contents:write, pull_requests:write"
+
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Approve pull request and enable auto-merge
+        shell: bash
+        if: |
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/cache') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/checkout') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/dependency-review-action') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/download-artifact') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/setup-dotnet') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/upload-artifact') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'dependabot/fetch-metadata') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'github/codeql-action')
+        env:
+          GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr checkout "$PR_URL"
+          if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
+          then gh pr review --approve "$PR_URL" && gh pr merge --auto --squash "$PR_URL"
+          fi

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: dependency-review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@f46c48ed6d4f1227fb2d9ea62bf6bcbed315589e # v3.0.4

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -1,124 +1,21 @@
 name: update-dotnet-sdk
 
-env:
-  GIT_COMMIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-  GIT_COMMIT_USER_NAME: github-actions[bot]
-  TERM: xterm
-
 on:
   schedule:
-    - cron:  '30 09 * * MON-FRI'
-    - cron:  '00 19 * * TUE'
+    - cron:  '00 21 * * TUE'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
-  update-dotnet-sdk:
-    name: Update .NET SDK
-    runs-on: ubuntu-latest
-    if: ${{ github.event.repository.fork == false }}
-
-    steps:
-
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Update .NET SDK
-      id: update-dotnet-sdk
-      uses: martincostello/update-dotnet-sdk@v2
-      with:
-        labels: "dependencies,.NET"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        user-email: ${{ env.GIT_COMMIT_USER_EMAIL }}
-        user-name: ${{ env.GIT_COMMIT_USER_NAME }}
-
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v3
-      if : ${{ steps.update-dotnet-sdk.outputs.sdk-updated == 'true' }}
-
-    - name: Update NuGet packages
-      if : ${{ steps.update-dotnet-sdk.outputs.sdk-updated == 'true' }}
-      shell: pwsh
-      env:
-        DOTNET_CLI_TELEMETRY_OPTOUT: true
-        DOTNET_NOLOGO: true
-        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
-        NUGET_XMLDOC_MODE: skip
-      run: |
-        $ErrorActionPreference = "Stop"
-
-        dotnet tool install --global dotnet-outdated-tool
-
-        $tempPath = [System.IO.Path]::GetTempPath()
-        $updatesPath = (Join-Path $tempPath "dotnet-outdated.json")
-
-        Write-Host "Checking for .NET NuGet package(s) to update..."
-
-        dotnet outdated `
-          --upgrade `
-          --version-lock Major `
-          --output $updatesPath `
-          --include "Microsoft.AspNetCore." `
-          --include "Microsoft.NET.Test.Sdk"
-
-        $dependencies = @()
-
-        if (Test-Path $updatesPath) {
-          $dependencies = `
-            Get-Content -Path $updatesPath | `
-            ConvertFrom-Json | `
-            Select-Object -ExpandProperty projects | `
-            Select-Object -ExpandProperty TargetFrameworks | `
-            Select-Object -ExpandProperty Dependencies | `
-            Sort-Object -Property Name -Unique
-        }
-
-        if ($dependencies.Count -gt 0) {
-          Write-Host "Found $($dependencies.Count) .NET NuGet package(s) to update." -ForegroundColor Green
-
-          $commitMessageLines = @()
-
-          if ($dependencies.Count -eq 1) {
-            $commitMessageLines += "Bump $($dependencies[0].Name) from $($dependencies[0].ResolvedVersion) to $($dependencies[0].LatestVersion)"
-            $commitMessageLines += ""
-            $commitMessageLines += "Bumps $($dependencies[0].Name) from $($dependencies[0].ResolvedVersion) to $($dependencies[0].LatestVersion)."
-          } else {
-            $commitMessageLines += "Bump .NET NuGet packages"
-            $commitMessageLines += ""
-            $commitMessageLines += "Bumps .NET dependencies to their latest versions for the .NET ${{ steps.update-dotnet-sdk.outputs.sdk-version }} SDK."
-            $commitMessageLines += ""
-            foreach ($dependency in $dependencies) {
-              $commitMessageLines += "Bumps $($dependency.Name) from $($dependency.ResolvedVersion) to $($dependency.LatestVersion)."
-            }
-          }
-
-          $commitMessageLines += ""
-          $commitMessageLines += "---"
-          $commitMessageLines += "updated-dependencies:"
-
-          foreach ($dependency in $dependencies) {
-            $commitMessageLines += "- dependency-name: $($dependency.Name)"
-            $commitMessageLines += "  dependency-type: direct:production"
-            $commitMessageLines += "  update-type: version-update:semver-$($dependency.UpgradeSeverity.ToLowerInvariant())"
-          }
-
-          $commitMessageLines += "..."
-          $commitMessageLines += ""
-          $commitMessageLines += ""
-
-          $commitMessage = $commitMessageLines -join "`n"
-
-          git config user.email "${{ env.GIT_COMMIT_USER_EMAIL }}"
-          git config user.name "${{ env.GIT_COMMIT_USER_NAME }}"
-
-          git add .
-          git commit -m $commitMessage
-          git push
-
-          Write-Host "Pushed update to $($dependencies.Count) NuGet package(s)." -ForegroundColor Green
-        }
-        else {
-          Write-Host "There are no .NET NuGet packages to update." -ForegroundColor Green
-        }
+  update-sdk:
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@a9c7965f8619036551db9aaa4d6ff5e186ccd700 # v2.1.2
+    with:
+      include-nuget-packages: "Microsoft.AspNetCore.,Microsoft.NET.Test.Sdk"
+      labels: "dependencies,.NET"
+      user-email: ${{ vars.UPDATER_COMMIT_USER_EMAIL }}
+      user-name: ${{ vars.UPDATER_COMMIT_USER_NAME }}
+    secrets:
+      application-id: ${{ secrets.UPDATER_APPLICATION_ID }}
+      application-private-key: ${{ secrets.UPDATER_APPLICATION_PRIVATE_KEY }}


### PR DESCRIPTION
This PR makes a number of changes to GitHub actions to automate more of the repo maintenance and also hardens the repo against various recommendations that are made by the Open Source Software Foundation (OSSF) Scorecard.

The automation is based on [the approaches in this repository](https://github.com/martincostello/dotnet-patch-automation-sample/tree/main#readme).

Changes:

- Add a GitHub Actions workflow to run a CodeQL scan.
- Add a workflow to [review dependencies](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review).
- Validates the NuGet packages before publishing.
- Publish packages to GitHub and NuGet as separate jobs after the build.
- Harden GitHub workflows by pinning actions by Git SHA.
- Add NuGet package caching.
- Use [reusable workflow](https://github.com/martincostello/update-dotnet-sdk/tree/main#advanced-workflow) for updating the .NET SDK.
- Use a GitHub app to generate updates instead of `GITHUB_TOKEN` so that CI runs.
- Add a workflow to automatically approve and merge .NET SDK updates.
- Add a workflow to automatically approve and merge dependabot updates for GitHub-authored actions.
