### PR TITLE
Fix pre-release reference in docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,7 +106,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-Note that the `AddJustSaying` extension method requires installing the [JustSaying.Extensions.DependencyInjection](https://www.nuget.org/packages/JustSaying.Extensions.DependencyInjection.Microsoft/7.0.0-beta.1) package, which is currently in pre-release.
+Note that the `AddJustSaying` extension method requires installing the [JustSaying.Extensions.DependencyInjection](https://www.nuget.org/packages/JustSaying.Extensions.DependencyInjection.Microsoft) package.
 
 ### Startup
 


### PR DESCRIPTION
JustSaying.Extensions.DependencyInjection.Microsoft is no longer in beta / pre-release, update docs to reflect this. No need to specify version in link now either.
