### PR TITLE
Add security policy and OpenSSF Scorecard badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: ossf-scorecard
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * MON'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+
+  analysis:
+    name: analysis
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@80e868c13c90f172d68d1f4501dee99e2479f7af # v2.1.3
+        with:
+          publish_results: true
+          results_file: results.sarif
+          results_format: sarif
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: SARIF
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@0225834cc549ee0ca93cb085b92954821a145866 # v2.3.5
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@
 [![Build status](https://img.shields.io/github/actions/workflow/status/justeattakeaway/JustSaying/build.yml?branch=main&logo=github)](https://github.com/justeattakeaway/JustSaying/actions?query=workflow%3Abuild+branch%3Amain)
 [![codecov](https://codecov.io/gh/justeattakeaway/JustSaying/branch/main/graph/badge.svg)](https://codecov.io/gh/justeattakeaway/JustSaying)
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/justeattakeaway/JustSaying/badge)]
+
 A helpful library for publishing and consuming events / messages over SNS (SNS / SQS as a message bus).
 
 ## Documentation
 
 Docs can be found [here](https://justeat.gitbook.io/justsaying/).
 
-## Contributing...
+## Contributing
 
 Please read the [contributing guide](./.github/CONTRIBUTING.md "Contributing to JustSaying").
 
-### The End.....
+### The End
 
 ..._Happy Messaging!..._

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To privately report a security vulnerability, please create a security advisory in the [repository's Security tab](https://github.com/justeattakeaway/JustSaying/security/advisories).
+
+Further details can be found in the [GitHub documentation](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).


### PR DESCRIPTION
- Add a security policy documenting how to report vulnerabilities.
- Add a GitHub Actions workflow to calculate the OpenSSF Scorecard score for the repository.
- Add a badge for the OpenSSF Scorecard to the README (will only work post-merge).
