### PR TITLE
Remove ExcludeByAttribute

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -59,7 +59,6 @@
     <CollectCoverage Condition=" '$(CollectCoverage)' == '' ">true</CollectCoverage>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[*.Benchmarks]*,[*Sample*]*,[*Test*]*,[xunit.*]*</Exclude>
-    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)$(PackageIcon)" Pack="True" PackagePath="" />


### PR DESCRIPTION
This is set automatically, so we shouldn't need to specify it.
