### PR TITLE
Update xunit dependencies together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,7 @@ updates:
     - ">= 4.7.a, < 4.8"
   - dependency-name: System.Text.Json
   - dependency-name: System.Threading.Channels
+  groups:
+    xunit:
+      patterns:
+        - xunit*


### PR DESCRIPTION
Adds a Dependabot group for Xunit so when there are multiple Xunit- packages updates, we can run CI and merge them together.