### PR TITLE
Use SHA-256 for checksums

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)justeat-oss.snk</AssemblyOriginatorKeyFile>
     <JustSayingKey>00240000048000009400000006020000002400005253413100040000010001009d30c64bc42ba5037aec3cf60334df3a4c140ffc1dab19fdd31c9765e4e29afa441396ff9437a764b618c6473a3b350c56d706a0fbe83915f1f250ee23eb548b30306187ac685f65caa48303dc86f08c1c24d99dc84966273c207eaa8570b440004c7f49cef4ec77bc69118610ae2b53db7d8abeb465cbcd4bd190feaf517aad</JustSayingKey>
     <Authors>JUSTEAT_OSS</Authors>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <Company>Just Eat</Company>
     <Copyright>Copyright (c) Just Eat 2015-$([System.DateTime]::Now.ToString(yyyy))</Copyright>


### PR DESCRIPTION
Fix `BA2004` warning from [Binskim](https://github.com/microsoft/binskim) which people using the library may run against it and ask questions about (this happened with Polly, which is how I know about this).
