### PR TITLE
Use Polly resilience pipelines

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="MinVer" Version="4.3.0" />
     <PackageVersion Include="morelinq" Version="4.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="Polly" Version="8.1.0" />
+    <PackageVersion Include="Polly.Core" Version="8.1.0" />
     <PackageVersion Include="ReportGenerator" Version="5.1.26" />
     <PackageVersion Include="Serilog" Version="3.0.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="7.0.0" />

--- a/samples/src/JustSaying.Sample.Middleware/JustSaying.Sample.Middleware.csproj
+++ b/samples/src/JustSaying.Sample.Middleware/JustSaying.Sample.Middleware.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="Polly" />
+    <PackageReference Include="Polly.Core" />
     <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 

--- a/src/JustSaying.Tools/JustSaying.Tools.csproj
+++ b/src/JustSaying.Tools/JustSaying.Tools.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net471</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/tests/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="MELT" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="Polly" />
+    <PackageReference Include="Polly.Core" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>


### PR DESCRIPTION
Update the Polly samples to use the new Polly v8 APIs.
