### PR TITLE
HandlerInvocationMiddleware will resolve services via the IHandlerResolver

### DIFF
--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerInvocationMiddleware.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerInvocationMiddleware.cs
@@ -6,9 +6,9 @@ namespace JustSaying.Messaging.Middleware;
 
 /// <summary>
 /// This middleware is responsible for recalling a previously resolved message handler and calling it.
+/// This class is obsolete and will be removed in a future version. Please use HandlerResolveInvocationMiddleware instead.
 /// </summary>
 /// <typeparam name="T">The type of the message that the message handler handles.</typeparam>
-[Obsolete("This class is obsolete and will be removed in a future version. Please use HandlerResolveInvocationMiddleware instead.")]
 public sealed class HandlerInvocationMiddleware<T>(Func<HandlerResolutionContext, IHandlerAsync<T>> handlerResolver) : MiddlewareBase<HandleMessageContext, bool> where T : Message
 {
     private readonly Func<HandlerResolutionContext, IHandlerAsync<T>> _handlerResolver = handlerResolver ?? throw new ArgumentNullException(nameof(handlerResolver));

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
@@ -95,7 +95,7 @@ Please check the documentation for your container for more details.");
                 $"Handler middleware has already been specified for {typeof(TMessage).Name} on this queue.");
         }
 
-        _handlerMiddleware = new HandlerInvocationMiddleware<TMessage>(handlerResolver.ResolveHandler<TMessage>);
+        _handlerMiddleware = new HandlerInvocationMiddleware<TMessage>(handlerResolver);
 
         return this;
     }

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
@@ -95,7 +95,7 @@ Please check the documentation for your container for more details.");
                 $"Handler middleware has already been specified for {typeof(TMessage).Name} on this queue.");
         }
 
-        _handlerMiddleware = new HandlerInvocationMiddleware<TMessage>(handlerResolver);
+        _handlerMiddleware = new HandlerResolveInvocationMiddleware<TMessage>(handlerResolver);
 
         return this;
     }

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilderExtensions.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace JustSaying.Messaging.Middleware;
 public static class HandlerMiddlewareBuilderExtensions
 {
     /// <summary>
-    /// Adds a <see cref="HandlerInvocationMiddleware{T}"/> to the current pipeline.
+    /// Adds a resolved handler <see cref="HandlerInvocationMiddleware{T}"/> to the current pipeline.
     /// </summary>
     /// <param name="builder">The current <see cref="HandlerMiddlewareBuilder"/>.</param>
     /// <param name="handler">A factory that creates <see cref="IHandlerAsync{T}"/> instances from
@@ -22,6 +22,28 @@ public static class HandlerMiddlewareBuilderExtensions
     /// <exception cref="ArgumentNullException">
     /// <paramref name="builder"/> or <paramref name="handler"/> is <see langword="null"/>.
     /// </exception>
+    [Obsolete("This method is obsolete and will be removed in a future version. Please use UseHandler(IHandlerResolver) instead.")]
+    public static HandlerMiddlewareBuilder UseHandler<TMessage>(
+        this HandlerMiddlewareBuilder builder,
+        Func<HandlerResolutionContext, IHandlerAsync<TMessage>> handler) where TMessage : Message
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        if (handler == null) throw new ArgumentNullException(nameof(handler));
+
+        return builder.Use(new HandlerInvocationMiddleware<TMessage>(handler));
+    }
+
+    /// <summary>
+    /// Adds a <see cref="HandlerResolveInvocationMiddleware{T}"/> to the current pipeline to resolve handlers on demand
+    /// </summary>
+    /// <param name="builder">The current <see cref="HandlerMiddlewareBuilder"/>.</param>
+    /// <param name="handlerResolver">A factory that creates <see cref="IHandlerAsync{T}"/> instances from
+    /// a <see cref="HandlerResolutionContext"/>.</param>
+    /// <typeparam name="TMessage">The type of the message that should be handled</typeparam>
+    /// <returns>The current <see cref="HandlerMiddlewareBuilder"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/> or <paramref name="handlerResolver"/> is <see langword="null"/>.
+    /// </exception>
     public static HandlerMiddlewareBuilder UseHandler<TMessage>(
         this HandlerMiddlewareBuilder builder,
         IHandlerResolver handlerResolver) where TMessage : Message
@@ -29,7 +51,7 @@ public static class HandlerMiddlewareBuilderExtensions
         if (builder == null) throw new ArgumentNullException(nameof(builder));
         if (handlerResolver == null) throw new ArgumentNullException(nameof(handlerResolver));
 
-        return builder.Use(new HandlerInvocationMiddleware<TMessage>(handlerResolver));
+        return builder.Use(new HandlerResolveInvocationMiddleware<TMessage>(handlerResolver));
     }
 
     /// <summary>

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilderExtensions.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilderExtensions.cs
@@ -13,6 +13,7 @@ public static class HandlerMiddlewareBuilderExtensions
 {
     /// <summary>
     /// Adds a resolved handler <see cref="HandlerInvocationMiddleware{T}"/> to the current pipeline.
+    /// This method will be deprecated and removed in a future version. Please use UseHandler(IHandlerResolver) instead.
     /// </summary>
     /// <param name="builder">The current <see cref="HandlerMiddlewareBuilder"/>.</param>
     /// <param name="handler">A factory that creates <see cref="IHandlerAsync{T}"/> instances from
@@ -22,7 +23,6 @@ public static class HandlerMiddlewareBuilderExtensions
     /// <exception cref="ArgumentNullException">
     /// <paramref name="builder"/> or <paramref name="handler"/> is <see langword="null"/>.
     /// </exception>
-    [Obsolete("This method is obsolete and will be removed in a future version. Please use UseHandler(IHandlerResolver) instead.")]
     public static HandlerMiddlewareBuilder UseHandler<TMessage>(
         this HandlerMiddlewareBuilder builder,
         Func<HandlerResolutionContext, IHandlerAsync<TMessage>> handler) where TMessage : Message

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilderExtensions.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilderExtensions.cs
@@ -24,12 +24,12 @@ public static class HandlerMiddlewareBuilderExtensions
     /// </exception>
     public static HandlerMiddlewareBuilder UseHandler<TMessage>(
         this HandlerMiddlewareBuilder builder,
-        Func<HandlerResolutionContext, IHandlerAsync<TMessage>> handler) where TMessage : Message
+        IHandlerResolver handlerResolver) where TMessage : Message
     {
         if (builder == null) throw new ArgumentNullException(nameof(builder));
-        if (handler == null) throw new ArgumentNullException(nameof(handler));
+        if (handlerResolver == null) throw new ArgumentNullException(nameof(handlerResolver));
 
-        return builder.Use(new HandlerInvocationMiddleware<TMessage>(handler));
+        return builder.Use(new HandlerInvocationMiddleware<TMessage>(handlerResolver));
     }
 
     /// <summary>

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerResolveInvocationMiddleware.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerResolveInvocationMiddleware.cs
@@ -10,6 +10,7 @@ namespace JustSaying.Messaging.Middleware;
 /// <typeparam name="T">The type of the message that the message handler handles.</typeparam>
 public sealed class HandlerResolveInvocationMiddleware<T>(IHandlerResolver handlerResolver) : MiddlewareBase<HandleMessageContext, bool> where T : Message
 {
+    /// <inheritdoc />
     protected override async Task<bool> RunInnerAsync(
         HandleMessageContext context,
         Func<CancellationToken, Task<bool>> func,

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenDefaultMiddlewaresAreNotApplied.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenDefaultMiddlewaresAreNotApplied.cs
@@ -21,7 +21,7 @@ public class WhenDefaultMiddlewaresAreNotApplied(ITestOutputHelper outputHelper)
                     c => c.WithMiddlewareConfiguration(m =>
                     {
                         m.Use(testMiddleware);
-                        m.UseHandler(_ => handler);
+                        m.UseHandler<SimpleMessage>(new DummyHandlerResolver<SimpleMessage>(handler));
                     })))
             .AddJustSayingHandlers(new[] { handler });
 

--- a/tests/JustSaying.TestingFramework/DummyHandlerResolver.cs
+++ b/tests/JustSaying.TestingFramework/DummyHandlerResolver.cs
@@ -1,0 +1,18 @@
+﻿using JustSaying.Messaging.MessageHandling;
+
+namespace JustSaying.TestingFramework;
+
+public class DummyHandlerResolver<T> : IHandlerResolver
+{
+    private readonly IHandlerAsync<T> _handler;
+
+    public DummyHandlerResolver(IHandlerAsync<T> handler)
+    {
+        _handler = handler;
+    }
+
+    public IHandlerAsync<TMessage> ResolveHandler<TMessage>(HandlerResolutionContext context)
+    {
+        return (IHandlerAsync<TMessage>)_handler;
+    }
+}

--- a/tests/JustSaying.UnitTests/Messaging/MessageHandling/WhenEnsuringMessageIsOnlyHandledExactlyOnce.cs
+++ b/tests/JustSaying.UnitTests/Messaging/MessageHandling/WhenEnsuringMessageIsOnlyHandledExactlyOnce.cs
@@ -27,7 +27,7 @@ public class WhenEnsuringMessageIsOnlyHandledExactlyOnce(ITestOutputHelper outpu
         var middleware = new HandlerMiddlewareBuilder(testResolver, testResolver)
             .UseExactlyOnce<OrderAccepted>(nameof(InspectableHandler<OrderAccepted>),
                 TimeSpan.FromSeconds(1))
-            .UseHandler(ctx => handler)
+            .UseHandler<OrderAccepted>(new DummyHandlerResolver<OrderAccepted>(handler))
             .Build();
 
         var context = TestHandleContexts.From<OrderAccepted>();

--- a/tests/JustSaying.UnitTests/Messaging/Middleware/HandlerMiddlewareBuilderTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Middleware/HandlerMiddlewareBuilderTests.cs
@@ -65,7 +65,7 @@ public class HandlerMiddlewareBuilderTests
             .Configure(hmb =>
                 hmb.Use(outer)
                     .Use(inner)
-                    .UseHandler(ctx => handler));
+                    .UseHandler<SimpleMessage>(new DummyHandlerResolver<SimpleMessage>(handler)));
 
         var handlerMiddleware = middlewareBuilder.Build();
 


### PR DESCRIPTION
# Why?

At the moment when the subscription pipeline is built the handlers are all resolved and cached. This causes an issue with other containers, such as SimpleInjector as we are unable to setup a scope for resolving injected instances within the handler itself.

# What does this do?

Instead of resolving all the handlers when the pipeline is built, we leverage the IHandlerResolver to resolver handlers on demand.

# Example of use

When using SimpleInjector, I could setup a middleware to run earlier in the pipeline to initialise a scope:

```csharp
    public class SimpleInjectorScopeMiddleware : MiddlewareBase<HandleMessageContext, bool>
    {
        private readonly Container _container;

        public SimpleInjectorScopeMiddleware(Container container)
        {
            _container = container;
        }

        protected override async Task<bool> RunInnerAsync(
            HandleMessageContext context,
            Func<CancellationToken, Task<bool>> func,
            CancellationToken stoppingToken)
        {
            await using (AsyncScopedLifestyle.BeginScope(_container))
            {
                return await func(stoppingToken);
            }
        }
    }


    // Somewhere else for convenience
    public static class MiddlewareExtensions
    {
        public static HandlerMiddlewareBuilder UseSimpleInjectorScope(this HandlerMiddlewareBuilder builder)
        {
            builder.Use<SimpleInjectorScopeMiddleware>();

            return builder;
        }
    }
```

This could then be added to a subscription as such:

```csharp
                        x.ForTopic<TestMessage>(
                            cfg =>
                            {
                                cfg.WithMiddlewareConfiguration(m => { m.UseSimpleInjectorScope(); });
                            });
```

Now when receiving a message, my handler will be resolved in scope and I can use injected dependencies correctly.

# Alternatives

There are other ways to solve this problem, the main one would be to allow us to swap in our own `HandlerInvocationMiddleware` - then we could do the scoping in there. However the docs state, and the code seems to reflect that we are unable to provide our own version. If we could, we could set this up as a global middleware and we wouldn't need to set this scoped middleware up on every subscription which would be great.

Another alternative is for us to use a library like Mediator, and every `IHandlerAsync<>` is simply a shell which invokes a mediator pipeline which then sets up our scoping. However, this seems really messy and a bleeding of concerns. In addition it would require us to make sweeping changes across our codebase to convert from v6 to v7.

As an aside, in v6 we define a wrapper when we instantiate the handler during setup which sets up the scope and then resolves the handler inside, effectively acting like a middleware, but this is no longer possible. However for reference:

```csharp
public class HandlerResolverWrapper<T> : IHandlerAsync<T>
{
    private readonly Container _container;

    public HandlerResolverWrapper(Container container)
    {
        _container = container;
    }

    public async Task<bool> Handle(T message)
    {
        await using (AsyncScopedLifestyle.BeginScope(_container))
        {
            try
            {
                var handler = _container.GetInstance<IHandlerAsync<T>>();

                return await handler.Handle(message);
            }
            catch (ActivationException ex)
            {
                Log.Logger.Error(ex, "Failed to find a handler for {messageType}", message.GetType().Name);

                return false;
            }
        }
    }
}
```

And it is configured as such:

```csharp
        stack.WithSqsTopicSubscriber()
                .IntoQueue(null)
                .WithMessageHandler(new HandlerResolverWrapper<TestMessage>(container));
```


Maybe I'm missing something completely obvious, but I have been playing with v7 and this has been a huge blocker for working with SimpleInjector which we use extensively.

If we could resolve this issue using my approach here (or similar), where the handlers are resolved on demand, it would also give cool middleware functionality, such as defining a subscription to have a UoW applied to it.

Order of middlewares would be:
* Scope (setup scope for handler resolution)
* UoW (pull session from container, begin a transaction)
* [internal middlewares, to resolving]
* UoW (handle commit/rollback)
* Scope (close down scope and resolved instances)

This PR isn't ready for merge, it needs a clean up, however from what I can see the `UseHandler<>` I modified was there solely for testing, so making this change would not produce any breaking changes. 

Would love to hear thoughts and start a discussion on this.

Many thanks!

Mike
