### PR TITLE
Add dedicated package README

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,13 +5,13 @@ Great! There are plenty of ways you can help!
 
 If you find a bug, have a feature request or even want to contribute an enhancement or fix, please follow the below guidelines so that we can help you out and/or get your code merged quickly.
 
-## If you find what looks like a bug:
+## If you find what looks like a bug
 
 * Check the [GitHub issue tracker](https://github.com/justeattakeaway/JustSaying/issues/ "JustSaying issues") to see if anyone else has reported the same issue.
 * Make sure you are using the latest version of JustSaying
 * If you are still having problems then [create an issue](https://github.com/justeattakeaway/JustSaying/issues/new/choose) with enough information so that it can be reproduced and diagnosed
 
-## If you want to contribute an enhancement or a fix:
+## If you want to contribute an enhancement or a fix
 
 1. Discuss any major enhancement with the project maintainers by creating either an [issue](https://github.com/justeattakeaway/JustSaying/issues/new/choose) or a [discussion](https://github.com/justeattakeaway/JustSaying/discussions).
 1. Work on your changes and add any relevant unit and/or functional tests.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ If you find a bug, have a feature request or even want to contribute an enhancem
 
 ## If you find what looks like a bug:
 
-* Check the [GitHub issue tracker](http://github.com/justeattakeaway/JustSaying/issues/ "JustSaying issues") to see if anyone else has reported the same issue.
+* Check the [GitHub issue tracker](https://github.com/justeattakeaway/JustSaying/issues/ "JustSaying issues") to see if anyone else has reported the same issue.
 * Make sure you are using the latest version of JustSaying
 * If you are still having problems then [create an issue](https://github.com/justeattakeaway/JustSaying/issues/new/choose) with enough information so that it can be reproduced and diagnosed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # 5.0.0
 
-See https://github.com/justeattakeaway/JustSaying/releases/tag/v5.0.0.
+See [here](https://github.com/justeattakeaway/JustSaying/releases/tag/v5.0.0).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,7 +68,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/justeattakeaway/JustSaying</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>package-readme.md</PackageReadmeFile>
     <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>aws,sns,sqs</PackageTags>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A helpful library for publishing and consuming events / messages over SNS (SNS /
 
 ## Documentation
 
-Docs can be found [here](https://justeat.gitbook.io/justsaying/).
+Documentation can be found [here](https://justeat.gitbook.io/justsaying/).
 
-If you want to contribute to the docs, they are in the [docs branch](https://github.com/justeattakeaway/JustSaying/tree/docs) - PRs should be issued against this branch.
+If you want to contribute to the documentation, they are in the [docs branch](https://github.com/justeattakeaway/JustSaying/tree/docs) - PRs should be issued against this branch.
 
 ## Contributing
 
@@ -22,4 +22,4 @@ Please read the [contributing guide](./.github/CONTRIBUTING.md "Contributing to 
 
 ### The End
 
-..._Happy Messaging!..._
+_Happy Messaging!_

--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,5 @@
+# Releases
+
 ## About Versioning
 
 JustSaying adopts [SemVer 2.0](https://semver.org/spec/v2.0.0.html), and uses [MinVer](https://github.com/adamralph/minver) to achieve this. [See here](https://github.com/adamralph/minver#how-it-works) for more information on how it works.

--- a/docs/Documentation_generation.md
+++ b/docs/Documentation_generation.md
@@ -7,18 +7,19 @@
 ## Integration with Visual Studio Code
 
 - Install the plugin
-    - [PlantUML plugin for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml)
+  - [PlantUML plugin for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml)
+  - Add the below to your user settings in Visual Studio Code
 
-    - Add the below to your user settings in Visual Studio Code
-
-    ```json
-        "plantuml.exportFormat": "png",
-        "plantuml.render": "PlantUMLServer",
-        "plantuml.server": "http://localhost:8080",
-        "plantuml.diagramsRoot": "docs",
-        "plantuml.exportOutDir": "docs",
-        "plantuml.exportSubFolder": false
-    ```
+  ```json
+  {
+    "plantuml.exportFormat": "png",
+    "plantuml.render": "PlantUMLServer",
+    "plantuml.server": "http://localhost:8080",
+    "plantuml.diagramsRoot": "docs",
+    "plantuml.exportOutDir": "docs",
+    "plantuml.exportSubFolder": false
+  }
+  ```
 
 - Run a [PlantUML Server](https://github.com/plantuml/plantuml-server) locally to translate from `.puml` files into `.png` images
 
@@ -27,14 +28,14 @@
     ```
 
 - To live preview an image while editing
-    - Open a `.puml`
-    - Press F1
-    - Select `PlantUML: Preview Current Diagram`
+  - Open a `.puml`
+  - Press F1
+  - Select `PlantUML: Preview Current Diagram`
 
 - To regenerate all images
-    - Press F1
-    - Select `PlantUML: Export workspace diagrams`
-    - All images in `/docs` will be regenerated
+  - Press F1
+  - Select `PlantUML: Export workspace diagrams`
+  - All images in `/docs` will be regenerated
 
 ## Further reading
 

--- a/docs/Documentation_generation.md
+++ b/docs/Documentation_generation.md
@@ -1,7 +1,8 @@
 # Documentation Generation
 
 ## PlantUML
-> PlantUML is used to draw UML diagrams, using a simple and human readable text description. [plantuml.com](http://plantuml.com/)
+
+> PlantUML is used to draw UML diagrams, using a simple and human readable text description. [plantuml.com](https://plantuml.com/)
 
 ## Integration with Visual Studio Code
 
@@ -36,5 +37,5 @@
     - All images in `/docs` will be regenerated
 
 ## Further reading
-- Further reading and examples available at:
-    - https://www.planttext.com/
+
+- Further reading and examples available at <https://www.planttext.com>

--- a/package-readme.md
+++ b/package-readme.md
@@ -1,0 +1,19 @@
+# JustSaying
+
+[![NuGet](https://img.shields.io/nuget/v/JustSaying.svg?maxAge=3600)](https://www.nuget.org/packages/JustSaying/)
+[![Build status](https://img.shields.io/github/actions/workflow/status/justeattakeaway/JustSaying/build.yml?branch=main&logo=github)](https://github.com/justeattakeaway/JustSaying/actions?query=workflow%3Abuild+branch%3Amain)
+[![codecov](https://codecov.io/gh/justeattakeaway/JustSaying/branch/main/graph/badge.svg)](https://codecov.io/gh/justeattakeaway/JustSaying)
+
+A helpful library for publishing and consuming events/messages over SNS (SNS/SQS as a message bus).
+
+## Documentation
+
+Documentation can be found [here](https://justeat.gitbook.io/justsaying/).
+
+## Feedback
+
+Any feedback or issues for this library can be added to the issues in [GitHub](https://github.com/justeattakeaway/JustSaying/issues "This package's issues on GitHub.com").
+
+## License
+
+This package is licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html "The Apache 2.0 license") license.

--- a/samples/src/JustSaying.Sample.Restaurant.OrderingApi/Properties/launchSettings.json
+++ b/samples/src/JustSaying.Sample.Restaurant.OrderingApi/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "sslPort": 44386
     }
   },
-  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",

--- a/src/JustSaying/Messaging/MessageAttributeValue.cs
+++ b/src/JustSaying/Messaging/MessageAttributeValue.cs
@@ -8,21 +8,21 @@ namespace JustSaying.Messaging;
 /// <summary>
 /// The user-specified message attribute value. For string data types, the value attribute
 /// has the same restrictions on the content as the message body. For more information,
-/// see <a href="http://docs.aws.amazon.com/sns/latest/api/API_Publish.html">Publish</a> in the AWS docs.
-/// 
-///  
+/// see <a href="https://docs.aws.amazon.com/sns/latest/api/API_Publish.html">Publish</a> in the AWS docs.
+///
+///
 /// <para>
 /// Name, type, and value must not be empty or null. In addition, the message body should
 /// not be empty or null. All parts of the message attribute, including name, type, and
 /// value, are included in the message size restriction, which is currently 256 KB (262,144
-/// bytes). For more information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html">Using
+/// bytes). For more information, see <a href="https://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html">Using
 /// Amazon SNS Message Attributes</a> in the AWS docs.
 /// </para>
 /// </summary>
 public class MessageAttributeValue
 {
     /// <summary>
-    /// Gets and sets the property BinaryValue. 
+    /// Gets and sets the property BinaryValue.
     /// <para>
     /// Binary type attributes can store any binary data, for example, compressed data, encrypted
     /// data, or images.
@@ -31,18 +31,18 @@ public class MessageAttributeValue
     public IReadOnlyCollection<byte> BinaryValue { get; set; }
 
     /// <summary>
-    /// Gets and sets the property StringValue. 
+    /// Gets and sets the property StringValue.
     /// <para>
-    /// Strings are Unicode with UTF8 binary encoding. For a list of code values, see <a href="http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters">http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.
-    /// </para>
+    /// Strings are Unicode with UTF8 binary encoding. For a list of code values, see <a href="https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters">https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.
+    /// /// </para>
     /// </summary>
     public string StringValue { get; set; }
 
     /// <summary>
-    /// Gets and sets the property DataType. 
+    /// Gets and sets the property DataType.
     /// <para>
     /// Amazon SNS supports the following logical data types: String, String.Array, Number,
-    /// and Binary. For more information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html#SNSMessageAttributes.DataTypes">Message
+    /// and Binary. For more information, see <a href="https://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html#SNSMessageAttributes.DataTypes">Message
     /// Attribute Data Types in the AWS docs</a>.
     /// </para>
     /// </summary>


### PR DESCRIPTION
NuGet.org's content security policy and reduced Markdown rendering support mean that the [project README doesn't render well as it could](https://www.nuget.org/packages/JustSaying#readme-body-tab) in the NuGet gallery. Instead, add a dedicated package README with pared-back information that will render better and is more context-specific.

Also updates some links from HTTP to HTTPS and fixes some Markdownlint warnings.
