### PR TITLE
Attest artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,11 @@ jobs:
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
 
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -74,6 +79,22 @@ jobs:
         with:
           file: ./artifacts/coverage/coverage.cobertura.xml
           flags: ${{ matrix.os_name }}
+
+      - name: Attest artifacts
+        uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
+        if: |
+          runner.os == 'Windows' &&
+          github.event.repository.fork == false &&
+          (github.ref_name == github.event.repository.default_branch ||
+           startsWith(github.ref, 'refs/tags/v'))
+        with:
+          subject-path: |
+            ./artifacts/publish/JustSaying/release*/JustSaying.dll
+            ./artifacts/publish/JustSaying.Extensions.Aws/release*/JustSaying.Extensions.Aws.dll
+            ./artifacts/publish/JustSaying.Extensions.DependencyInjection.Microsoft/release*/JustSaying.Extensions.DependencyInjection.Microsoft.dll
+            ./artifacts/publish/JustSaying.Extensions.DependencyInjection.StructureMap/release*/JustSaying.Extensions.DependencyInjection.StructureMap.dll
+            ./artifacts/publish/JustSaying.Models/release*/JustSaying.Models.dll
+            ./artifacts/package/release/*
 
       - name: Publish NuGet packages
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -33,6 +33,6 @@ jobs:
       run: echo "::add-matcher::.github/actionlint-matcher.json"
 
     - name: Lint workflows
-      uses: docker://rhysd/actionlint@sha256:2eb91a78b5a19140be099c7b4262d298c2567f2a9f27e10ed2a4323c5bcface8 # v1.6.26
+      uses: docker://rhysd/actionlint@sha256:5acca218639222e4afbc82fc6e9ef56cbe646ade3b07f3f5ec364b638258a244 # v1.7.0
       with:
         args: -color

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.binlog
 *.cache
 *.coverage
 *.idea


### PR DESCRIPTION
- Attest the binaries and packages from the build artifacts.
- Ignore binlog files.
