### PR TITLE
.NET 9 preparation

### DIFF
--- a/CodeAnalysisRules.ruleset
+++ b/CodeAnalysisRules.ruleset
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="CodeProjects" Description="Code analysis rules for JustSaying Code." ToolsVersion="15.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1303" Action="None" />
     <Rule Id="CA1308" Action="None" />
+    <Rule Id="CA1515" Action="None" />
   </Rules>
 </RuleSet>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <NoWarn>$(NoWarn);CA1062;CA1303</NoWarn>
+    <NuGetAuditMode>direct</NuGetAuditMode>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/justeattakeaway/JustSaying</PackageProjectUrl>


### PR DESCRIPTION
- Move suppressions to `.ruleset` file.
- Set `NuGetAuditMode=direct`.

Cherry-picked from #1358.
