### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,32 +14,21 @@ updates:
     - "justeattakeaway/justsaying-maintainers"
   open-pull-requests-limit: 10
   ignore:
-  - dependency-name: AWSSDK.Extensions.NETCore.Setup
-  - dependency-name: AWSSDK.SimpleNotificationService
-    versions:
-    - "> 3.3.100.1, < 3.8"
-  - dependency-name: AWSSDK.SQS
-    versions:
-    - "> 3.3.100.1, < 3.8"
-  - dependency-name: Microsoft.Bcl.AsyncInterfaces
-  - dependency-name: Microsoft.Extensions.Configuration
-  - dependency-name: Microsoft.Extensions.DependencyInjection.Abstractions
-    versions:
-    - "> 1.1.0"
-  - dependency-name: Microsoft.Extensions.Logging.Abstractions
-    versions:
-    - "> 2.0.0"
-  - dependency-name: Newtonsoft.Json
-    versions:
-    - "> 9.0.1"
-  - dependency-name: structuremap
-    versions:
-    - "> 4.6.0, < 5"
-  - dependency-name: structuremap
-    versions:
-    - ">= 4.7.a, < 4.8"
-  - dependency-name: System.Text.Json
-  - dependency-name: System.Threading.Channels
+    - dependency-name: AWSSDK.Extensions.NETCore.Setup
+    - dependency-name: AWSSDK.SimpleNotificationService
+    - dependency-name: AWSSDK.SQS
+    - dependency-name: Microsoft.Bcl.AsyncInterfaces
+    - dependency-name: Microsoft.Extensions.Configuration
+    - dependency-name: Microsoft.Extensions.Configuration.EnvironmentVariables
+    - dependency-name: Microsoft.Extensions.Configuration.Json
+    - dependency-name: Microsoft.Extensions.DependencyInjection
+    - dependency-name: Microsoft.Extensions.DependencyInjection.Abstractions
+    - dependency-name: Microsoft.Extensions.Logging.Abstractions
+    - dependency-name: Microsoft.Extensions.Logging.Console
+    - dependency-name: Newtonsoft.Json
+    - dependency-name: structuremap
+    - dependency-name: System.Text.Json
+    - dependency-name: System.Threading.Channels
   groups:
     xunit:
       patterns:


### PR DESCRIPTION
- Ignore various packages to stop updates to .NET 9.
- Simplify ignore config.
