### PR TITLE
Fix workflow warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,6 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./artifacts/coverage/coverage.cobertura.xml
           flags: ${{ matrix.os-name }}
 
       - name: Generate SBOM


### PR DESCRIPTION
Remove deprecated `file` input for codecov/codecov-action.
