### PR TITLE
Fix StructureMap Transient Middleware Resolution

### DIFF
--- a/src/JustSaying.Extensions.DependencyInjection.StructureMap/JustSayingRegistry.cs
+++ b/src/JustSaying.Extensions.DependencyInjection.StructureMap/JustSayingRegistry.cs
@@ -41,8 +41,8 @@ internal sealed class JustSayingRegistry : Registry
         For<IMessageContextAccessor>().Use(context => context.GetInstance<MessageContextAccessor>());
         For<IMessageContextReader>().Use(context => context.GetInstance<MessageContextAccessor>());
 
-        For<LoggingMiddleware>().Transient();
-        For<SqsPostProcessorMiddleware>().Transient();
+        For<LoggingMiddleware>().AlwaysUnique();
+        For<SqsPostProcessorMiddleware>().AlwaysUnique();
 
         For<IMessageSerializationRegister>()
             .Use(

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
@@ -38,7 +38,7 @@ public sealed class HandlerMiddlewareBuilder(IHandlerResolver handlerResolver, I
         {
             throw new InvalidOperationException(
                 @"Middlewares must be registered into your DI container such that each resolution creates a new instance.
-For StructureMap use Transient(), and for Microsoft.Extensions.DependencyInjection, use AddTransient().
+For StructureMap use AlwaysUnique(), and for Microsoft.Extensions.DependencyInjection, use AddTransient().
 Please check the documentation for your container for more details.");
         }
 

--- a/tests/JustSaying.TestingFramework/Patiently.cs
+++ b/tests/JustSaying.TestingFramework/Patiently.cs
@@ -31,16 +31,20 @@ public static class Patiently
         ITestOutputHelper output,
         Func<bool> func,
         [System.Runtime.CompilerServices.CallerMemberName]
-        string memberName = "")
-        => await AssertThatAsyncInner(output, func, 5.Seconds(), memberName).ConfigureAwait(false);
+        string memberName = "",
+        [System.Runtime.CompilerServices.CallerArgumentExpression("func")]
+        string assertionExpression = "")
+        => await AssertThatAsyncInner(output, func, 5.Seconds(), memberName, assertionExpression).ConfigureAwait(false);
 
     public static async Task AssertThatAsync(
         ITestOutputHelper output,
         Func<bool> func,
         TimeSpan timeout,
         [System.Runtime.CompilerServices.CallerMemberName]
-        string memberName = "")
-        => await AssertThatAsyncInner(output, func, timeout, memberName).ConfigureAwait(false);
+        string memberName = "",
+        [System.Runtime.CompilerServices.CallerArgumentExpression("func")]
+        string assertionExpression = "")
+        => await AssertThatAsyncInner(output, func, timeout, memberName, assertionExpression).ConfigureAwait(false);
 
     public static async Task AssertThatAsync(ITestOutputHelper output, Func<Task<bool>> func) =>
         await AssertThatAsync(output, func, 5.Seconds()).ConfigureAwait(false);
@@ -80,7 +84,8 @@ public static class Patiently
         ITestOutputHelper output,
         Func<bool> func,
         TimeSpan timeout,
-        string description)
+        string description,
+        string assertionExpression)
     {
         var watch = new Stopwatch();
         watch.Start();
@@ -106,7 +111,7 @@ public static class Patiently
                 $"Waiting for {watch.Elapsed.TotalMilliseconds} ms - Still waiting for {description}.");
         } while (watch.Elapsed < timeout);
 
-        func.Invoke().ShouldBeTrue();
+        func.Invoke().ShouldBeTrue($"Failed to assert that {assertionExpression} within {timeout}");
     }
 }
 


### PR DESCRIPTION
In StructureMap the Transient lifetime is more akin to MEDI's Scoped lifetime, where a single object instance will be created for each top level call to `Container.GetInstance()`.

Currently, the JustSayingRegistry causes a throw at startup if you don't clear and re-register these middleware as AlwaysUnique.

https://structuremap.github.io/object-lifecycle/supported-lifecycles/

