### PR TITLE
Remove reviewers property from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
   schedule:
     interval: daily
     timezone: Europe/London
-  reviewers:
-    - "justeattakeaway/justsaying-maintainers"
   open-pull-requests-limit: 10
   ignore:
     - dependency-name: AWSSDK.Extensions.NETCore.Setup


### PR DESCRIPTION
Per https://github.com/justeattakeaway/JustSaying/pull/1691#issuecomment-2852980286 the reviewers property is being deprecated, and we already have a CODEOWNERS file configured, so we can remove this.
