### PR TITLE
v9: AsyncAPI 3.0 document generation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,8 +9,10 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" Condition=" '$(TargetFramework)' == 'net8.0' " />
     <PackageVersion Include="System.Threading.Channels" Version="9.0.6" Condition=" '$(TargetFramework)' == 'net462' " />
     <PackageVersion Include="System.Threading.Channels" Version="9.0.6" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
+    <PackageVersion Include="ByteBard.AsyncAPI.NET" Version="3.0.1" />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" Condition=" '$(TargetFramework)' == 'net462' " />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
+    <PackageVersion Include="System.Text.Json" Version="10.0.11" Condition=" '$(TargetFramework)' == 'net8.0' " />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.18.0" />

--- a/JustSaying.slnx
+++ b/JustSaying.slnx
@@ -53,6 +53,7 @@
     <File Path=".github/workflows/update-dotnet-sdk.yml" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="src/JustSaying.AsyncApi/JustSaying.AsyncApi.csproj" />
     <Project Path="src/JustSaying.CloudEvents/JustSaying.CloudEvents.csproj" />
     <Project Path="src/JustSaying.Extensions.Aws/JustSaying.Extensions.Aws.csproj" />
     <Project Path="src/JustSaying.Extensions.DependencyInjection.Microsoft/JustSaying.Extensions.DependencyInjection.Microsoft.csproj" />
@@ -63,6 +64,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/JustSaying.AotTest/JustSaying.AotTest.csproj" />
+    <Project Path="tests/JustSaying.AsyncApi.Tests/JustSaying.AsyncApi.Tests.csproj" />
     <Project Path="tests/JustSaying.CloudEvents.Tests/JustSaying.CloudEvents.Tests.csproj" />
     <Project Path="tests/JustSaying.Benchmark/JustSaying.Benchmark.csproj" />
     <Project Path="tests/JustSaying.Extensions.Aws.Tests/JustSaying.Extensions.Aws.Tests.csproj" />

--- a/JustSaying.slnx
+++ b/JustSaying.slnx
@@ -53,6 +53,7 @@
     <File Path=".github/workflows/update-dotnet-sdk.yml" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="src/JustSaying.AsyncApi.BuildTools/JustSaying.AsyncApi.BuildTools.csproj" />
     <Project Path="src/JustSaying.AsyncApi/JustSaying.AsyncApi.csproj" />
     <Project Path="src/JustSaying.CloudEvents/JustSaying.CloudEvents.csproj" />
     <Project Path="src/JustSaying.Extensions.Aws/JustSaying.Extensions.Aws.csproj" />
@@ -64,6 +65,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/JustSaying.AotTest/JustSaying.AotTest.csproj" />
+    <Project Path="tests/JustSaying.AsyncApi.Tests.App/JustSaying.AsyncApi.Tests.App.csproj" />
     <Project Path="tests/JustSaying.AsyncApi.Tests/JustSaying.AsyncApi.Tests.csproj" />
     <Project Path="tests/JustSaying.CloudEvents.Tests/JustSaying.CloudEvents.Tests.csproj" />
     <Project Path="tests/JustSaying.Benchmark/JustSaying.Benchmark.csproj" />

--- a/build.ps1
+++ b/build.ps1
@@ -24,11 +24,14 @@ $libraryProjects = @(
     (Join-Path $solutionPath "src" "JustSaying.Extensions.Aws" "JustSaying.Extensions.Aws.csproj"),
     (Join-Path $solutionPath "src" "JustSaying.Extensions.DependencyInjection.Microsoft" "JustSaying.Extensions.DependencyInjection.Microsoft.csproj"),
     (Join-Path $solutionPath "src" "JustSaying.Extensions.DependencyInjection.StructureMap" "JustSaying.Extensions.DependencyInjection.StructureMap.csproj"),
-    (Join-Path $solutionPath "src" "JustSaying.Extensions.OpenTelemetry" "JustSaying.Extensions.OpenTelemetry.csproj")
+    (Join-Path $solutionPath "src" "JustSaying.Extensions.OpenTelemetry" "JustSaying.Extensions.OpenTelemetry.csproj"),
+    (Join-Path $solutionPath "src" "JustSaying.AsyncApi" "JustSaying.AsyncApi.csproj"),
+    (Join-Path $solutionPath "src" "JustSaying.AsyncApi.BuildTools" "JustSaying.AsyncApi.BuildTools.csproj")
 )
 
 $testProjects = @(
     (Join-Path $solutionPath "tests" "JustSaying.UnitTests" "JustSaying.UnitTests.csproj"),
+    (Join-Path $solutionPath "tests" "JustSaying.AsyncApi.Tests" "JustSaying.AsyncApi.Tests.csproj"),
     (Join-Path $solutionPath "tests" "JustSaying.Extensions.DependencyInjection.StructureMap.Tests" "JustSaying.Extensions.DependencyInjection.StructureMap.Tests.csproj"),
     (Join-Path $solutionPath "tests" "JustSaying.Extensions.OpenTelemetry.Tests" "JustSaying.Extensions.OpenTelemetry.Tests.csproj")
 )

--- a/build.ps1
+++ b/build.ps1
@@ -25,6 +25,7 @@ $libraryProjects = @(
     (Join-Path $solutionPath "src" "JustSaying.Extensions.DependencyInjection.Microsoft" "JustSaying.Extensions.DependencyInjection.Microsoft.csproj"),
     (Join-Path $solutionPath "src" "JustSaying.Extensions.DependencyInjection.StructureMap" "JustSaying.Extensions.DependencyInjection.StructureMap.csproj"),
     (Join-Path $solutionPath "src" "JustSaying.Extensions.OpenTelemetry" "JustSaying.Extensions.OpenTelemetry.csproj"),
+    (Join-Path $solutionPath "src" "JustSaying.CloudEvents" "JustSaying.CloudEvents.csproj"),
     (Join-Path $solutionPath "src" "JustSaying.AsyncApi" "JustSaying.AsyncApi.csproj"),
     (Join-Path $solutionPath "src" "JustSaying.AsyncApi.BuildTools" "JustSaying.AsyncApi.BuildTools.csproj")
 )

--- a/src/JustSaying.AsyncApi.BuildTools/HostFactoryResolver.cs
+++ b/src/JustSaying.AsyncApi.BuildTools/HostFactoryResolver.cs
@@ -1,0 +1,387 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+// Copied unmodified from dotnet/runtime
+// (src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs),
+// the same shared source used by Entity Framework Core's tools and ASP.NET Core's
+// GetDocument.Insider to capture an application's IHost without running it.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.Hosting
+{
+    internal sealed class HostFactoryResolver
+    {
+        private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+        public const string BuildWebHost = nameof(BuildWebHost);
+        public const string CreateWebHostBuilder = nameof(CreateWebHostBuilder);
+        public const string CreateHostBuilder = nameof(CreateHostBuilder);
+        private const string TimeoutEnvironmentKey = "DOTNET_HOST_FACTORY_RESOLVER_DEFAULT_TIMEOUT_IN_SECONDS";
+
+        // The amount of time we wait for the diagnostic source events to fire
+        private static readonly TimeSpan s_defaultWaitTimeout = SetupDefaultTimeout();
+
+        private static TimeSpan SetupDefaultTimeout()
+        {
+            if (Debugger.IsAttached)
+            {
+                return Timeout.InfiniteTimeSpan;
+            }
+
+            if (uint.TryParse(Environment.GetEnvironmentVariable(TimeoutEnvironmentKey), out uint timeoutInSeconds))
+            {
+                return TimeSpan.FromSeconds((int)timeoutInSeconds);
+            }
+
+            return TimeSpan.FromMinutes(5);
+        }
+
+        public static Func<string[], TWebHost>? ResolveWebHostFactory<TWebHost>(Assembly assembly)
+        {
+            return ResolveFactory<TWebHost>(assembly, BuildWebHost);
+        }
+
+        public static Func<string[], TWebHostBuilder>? ResolveWebHostBuilderFactory<TWebHostBuilder>(Assembly assembly)
+        {
+            return ResolveFactory<TWebHostBuilder>(assembly, CreateWebHostBuilder);
+        }
+
+        public static Func<string[], THostBuilder>? ResolveHostBuilderFactory<THostBuilder>(Assembly assembly)
+        {
+            return ResolveFactory<THostBuilder>(assembly, CreateHostBuilder);
+        }
+
+        // This helpers encapsulates all of the complex logic required to:
+        // 1. Execute the entry point of the specified assembly in a different thread.
+        // 2. Wait for the diagnostic source events to fire
+        // 3. Give the caller a chance to execute logic to mutate the IHostBuilder
+        // 4. Resolve the instance of the applications's IHost
+        // 5. Allow the caller to determine if the entry point has completed
+        public static Func<string[], object>? ResolveHostFactory(Assembly assembly,
+                                                                 TimeSpan? waitTimeout = null,
+                                                                 bool stopApplication = true,
+                                                                 Action<object>? configureHostBuilder = null,
+                                                                 Action<Exception?>? entrypointCompleted = null,
+                                                                 IDictionary<string, Action<object?>>? arbitraryActions = null)
+        {
+            if (assembly.EntryPoint is null)
+            {
+                return null;
+            }
+
+            try
+            {
+                // Attempt to load hosting and check the version to make sure the events
+                // even have a chance of firing (they were added in .NET >= 6)
+                var hostingAssembly = Assembly.Load("Microsoft.Extensions.Hosting");
+                if (hostingAssembly.GetName().Version is Version version && version.Major < 6)
+                {
+                    return null;
+                }
+
+                // We're using a version >= 6 so the events can fire. If they don't fire
+                // then it's because the application isn't using the hosting APIs
+            }
+            catch
+            {
+                // There was an error loading the extensions assembly, return null.
+                return null;
+            }
+
+            return args => new HostingListener(args, assembly.EntryPoint, waitTimeout ?? s_defaultWaitTimeout, stopApplication, configureHostBuilder, entrypointCompleted, arbitraryActions).CreateHost();
+        }
+
+        private static Func<string[], T>? ResolveFactory<T>(Assembly assembly, string name)
+        {
+            var programType = assembly?.EntryPoint?.DeclaringType;
+            if (programType == null)
+            {
+                return null;
+            }
+
+            var factory = programType.GetMethod(name, DeclaredOnlyLookup);
+            if (!IsFactory<T>(factory))
+            {
+                return null;
+            }
+
+            return args => (T)factory!.Invoke(null, new object[] { args })!;
+        }
+
+        // TReturn Factory(string[] args);
+        private static bool IsFactory<TReturn>(MethodInfo? factory)
+        {
+            return factory != null
+                && typeof(TReturn).IsAssignableFrom(factory.ReturnType)
+                && factory.GetParameters().Length == 1
+                && typeof(string[]).Equals(factory.GetParameters()[0].ParameterType);
+        }
+
+        // Used by EF tooling without any Hosting references. Looses some return type safety checks.
+        public static Func<string[], IServiceProvider?>? ResolveServiceProviderFactory(Assembly assembly, TimeSpan? waitTimeout = null)
+        {
+            // Prefer the older patterns by default for back compat.
+            var webHostFactory = ResolveWebHostFactory<object>(assembly);
+            if (webHostFactory != null)
+            {
+                return args =>
+                {
+                    var webHost = webHostFactory(args);
+                    return GetServiceProvider(webHost);
+                };
+            }
+
+            var webHostBuilderFactory = ResolveWebHostBuilderFactory<object>(assembly);
+            if (webHostBuilderFactory != null)
+            {
+                return args =>
+                {
+                    var webHostBuilder = webHostBuilderFactory(args);
+                    var webHost = Build(webHostBuilder);
+                    return GetServiceProvider(webHost);
+                };
+            }
+
+            var hostBuilderFactory = ResolveHostBuilderFactory<object>(assembly);
+            if (hostBuilderFactory != null)
+            {
+                return args =>
+                {
+                    var hostBuilder = hostBuilderFactory(args);
+                    var host = Build(hostBuilder);
+                    return GetServiceProvider(host);
+                };
+            }
+
+            var hostFactory = ResolveHostFactory(assembly, waitTimeout: waitTimeout);
+            if (hostFactory != null)
+            {
+                return args =>
+                {
+                    static bool IsApplicationNameArg(string arg)
+                        => arg.Equals("--applicationName", StringComparison.OrdinalIgnoreCase) ||
+                            arg.Equals("/applicationName", StringComparison.OrdinalIgnoreCase);
+
+                    if (!args.Any(arg => IsApplicationNameArg(arg)) && assembly.GetName().Name is string assemblyName)
+                    {
+                        args = args.Concat(new[] { "--applicationName", assemblyName }).ToArray();
+                    }
+
+                    var host = hostFactory(args);
+                    return GetServiceProvider(host);
+                };
+            }
+
+            return null;
+        }
+
+        private static object? Build(object builder)
+        {
+            var buildMethod = builder.GetType().GetMethod("Build");
+            return buildMethod?.Invoke(builder, Array.Empty<object>());
+        }
+
+        private static IServiceProvider? GetServiceProvider(object? host)
+        {
+            if (host == null)
+            {
+                return null;
+            }
+            var hostType = host.GetType();
+            var servicesProperty = hostType.GetProperty("Services", DeclaredOnlyLookup);
+            return (IServiceProvider?)servicesProperty?.GetValue(host);
+        }
+
+        private sealed class HostingListener : IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object?>>
+        {
+            private readonly string[] _args;
+            private readonly MethodInfo _entryPoint;
+            private readonly TimeSpan _waitTimeout;
+            private readonly bool _stopApplication;
+
+            private readonly TaskCompletionSource<object> _hostTcs = new();
+            private IDisposable? _disposable;
+            private readonly Action<object>? _configure;
+            private readonly Action<Exception?>? _entrypointCompleted;
+            private readonly IDictionary<string, Action<object?>>? _arbitraryActions;
+            private static readonly AsyncLocal<HostingListener> _currentListener = new();
+
+            public HostingListener(
+                string[] args,
+                MethodInfo entryPoint,
+                TimeSpan waitTimeout,
+                bool stopApplication,
+                Action<object>? configure,
+                Action<Exception?>? entrypointCompleted,
+                IDictionary<string, Action<object?>>? arbitraryActions)
+            {
+                _args = args;
+                _entryPoint = entryPoint;
+                _waitTimeout = waitTimeout;
+                _stopApplication = stopApplication;
+                _configure = configure;
+                _entrypointCompleted = entrypointCompleted;
+                _arbitraryActions = arbitraryActions;
+            }
+
+            public object CreateHost()
+            {
+                using var subscription = DiagnosticListener.AllListeners.Subscribe(this);
+
+                // Kick off the entry point on a new thread so we don't block the current one
+                // in case we need to timeout the execution
+                var thread = new Thread(() =>
+                {
+                    Exception? exception = null;
+
+                    try
+                    {
+                        // Set the async local to the instance of the HostingListener so we can filter events that
+                        // aren't scoped to this execution of the entry point.
+                        _currentListener.Value = this;
+
+                        var parameters = _entryPoint.GetParameters();
+                        if (parameters.Length == 0)
+                        {
+                            _entryPoint.Invoke(null, Array.Empty<object>());
+                        }
+                        else
+                        {
+                            _entryPoint.Invoke(null, new object[] { _args });
+                        }
+
+                        // Try to set an exception if the entry point returns gracefully, this will force
+                        // build to throw
+                        _hostTcs.TrySetException(new InvalidOperationException("The entry point exited without ever building an IHost."));
+                    }
+                    catch (TargetInvocationException tie) when (tie.InnerException?.GetType().Name == "HostAbortedException")
+                    {
+                        // The host was stopped by our own logic
+                    }
+                    catch (TargetInvocationException tie)
+                    {
+                        exception = tie.InnerException ?? tie;
+
+                        // Another exception happened, propagate that to the caller
+                        _hostTcs.TrySetException(exception);
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ex;
+
+                        // Another exception happened, propagate that to the caller
+                        _hostTcs.TrySetException(ex);
+                    }
+                    finally
+                    {
+                        // Signal that the entry point is completed
+                        _entrypointCompleted?.Invoke(exception);
+                    }
+                })
+                {
+                    // Make sure this doesn't hang the process
+                    IsBackground = true
+                };
+
+                // Start the thread
+                thread.Start();
+
+                try
+                {
+                    // Wait before throwing an exception
+                    if (!_hostTcs.Task.Wait(_waitTimeout))
+                    {
+                        throw new InvalidOperationException($"Timed out waiting for the entry point to build the IHost after {s_defaultWaitTimeout}. This timeout can be modified using the '{TimeoutEnvironmentKey}' environment variable.");
+                    }
+                }
+                catch (AggregateException) when (_hostTcs.Task.IsCompleted)
+                {
+                    // Lets this propagate out of the call to GetAwaiter().GetResult()
+                }
+
+                Debug.Assert(_hostTcs.Task.IsCompleted);
+
+                return _hostTcs.Task.GetAwaiter().GetResult();
+            }
+
+            public void OnCompleted()
+            {
+                _disposable?.Dispose();
+            }
+
+            public void OnError(Exception error)
+            {
+
+            }
+
+            public void OnNext(DiagnosticListener value)
+            {
+                if (_currentListener.Value != this)
+                {
+                    // Ignore events that aren't for this listener
+                    return;
+                }
+
+                if (value.Name == "Microsoft.Extensions.Hosting")
+                {
+                    _disposable = value.Subscribe(this);
+                }
+            }
+
+            public void OnNext(KeyValuePair<string, object?> value)
+            {
+                if (_currentListener.Value != this)
+                {
+                    // Ignore events that aren't for this listener
+                    return;
+                }
+
+                if (value.Key == "HostBuilding")
+                {
+                    _configure?.Invoke(value.Value!);
+                }
+                else if (value.Key == "HostBuilt")
+                {
+                    _hostTcs.TrySetResult(value.Value!);
+
+                    if (_stopApplication)
+                    {
+                        // Stop the host from running further
+                        ThrowHostAborted();
+                    }
+                }
+                else if (_arbitraryActions?.TryGetValue(value.Key, out var arbitraryAction) == true)
+                {
+                    arbitraryAction.Invoke(value.Value);
+                }
+            }
+
+            // HostFactoryResolver is used by tools that explicitly don't want to reference Microsoft.Extensions.Hosting assemblies.
+            // So don't depend on the public HostAbortedException directly. Instead, load the exception type dynamically if it can
+            // be found. If it can't (possibly because the app is using an older version), throw a private exception with the same name.
+            private void ThrowHostAborted()
+            {
+                Type? publicHostAbortedExceptionType = Type.GetType("Microsoft.Extensions.Hosting.HostAbortedException, Microsoft.Extensions.Hosting.Abstractions", throwOnError: false);
+                if (publicHostAbortedExceptionType != null)
+                {
+                    throw (Exception)Activator.CreateInstance(publicHostAbortedExceptionType)!;
+                }
+                else
+                {
+                    throw new HostAbortedException();
+                }
+            }
+
+            private sealed class HostAbortedException : Exception
+            {
+            }
+        }
+    }
+}

--- a/src/JustSaying.AsyncApi.BuildTools/JustSaying.AsyncApi.BuildTools.csproj
+++ b/src/JustSaying.AsyncApi.BuildTools/JustSaying.AsyncApi.BuildTools.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>JustSaying.AsyncApi.GetDocument</AssemblyName>
+    <Description>Build-time AsyncAPI document generation for applications that use JustSaying.</Description>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IsPackable>true</IsPackable>
+    <Nullable>enable</Nullable>
+    <!-- The package intentionally has no lib/ folder or dependencies; it ships a tool and MSBuild targets. -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <OutputType>Exe</OutputType>
+    <PackageId>JustSaying.AsyncApi.BuildTools</PackageId>
+    <PackageTags>aws,sns,sqs,asyncapi,msbuild</PackageTags>
+    <RootNamespace>JustSaying.AsyncApi.GetDocument</RootNamespace>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <TargetFramework>net8.0</TargetFramework>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_PackGetDocumentTool</TargetsForTfmSpecificContentInPackage>
+    <UseAppHost>false</UseAppHost>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="build\**" Pack="true" PackagePath="build" />
+  </ItemGroup>
+  <Target Name="_PackGetDocumentTool">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(TargetPath)" PackagePath="tools/net8.0/" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/JustSaying.AsyncApi.BuildTools/JustSaying.AsyncApi.BuildTools.csproj
+++ b/src/JustSaying.AsyncApi.BuildTools/JustSaying.AsyncApi.BuildTools.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="build\**" Pack="true" PackagePath="build" />
+    <None Include="buildMultiTargeting\**" Pack="true" PackagePath="buildMultiTargeting" />
   </ItemGroup>
   <Target Name="_PackGetDocumentTool">
     <ItemGroup>

--- a/src/JustSaying.AsyncApi.BuildTools/Program.cs
+++ b/src/JustSaying.AsyncApi.BuildTools/Program.cs
@@ -174,7 +174,10 @@ internal static class Program
             var filePath = Path.Combine(outputDirectory, GetDocumentFileName(documentName, fileName));
 
             using var writer = new StringWriter();
-            var task = (Task)generateAsync.Invoke(provider, [documentName, writer, CancellationToken.None])!;
+
+            // Generation runs synchronously up to its first await, so the call itself is made on
+            // the worker task; invoking it here would leave that work outside the timeout.
+            var task = Task.Run(() => (Task)generateAsync.Invoke(provider, [documentName, writer, CancellationToken.None])!);
             if (!task.Wait(GenerationTimeout))
             {
                 return Error(9, $"Generating the AsyncAPI document '{documentName}' did not complete within {GenerationTimeout.TotalSeconds:0} seconds.");

--- a/src/JustSaying.AsyncApi.BuildTools/Program.cs
+++ b/src/JustSaying.AsyncApi.BuildTools/Program.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Hosting;
 
 namespace JustSaying.AsyncApi.GetDocument;
@@ -16,6 +17,8 @@ internal static class Program
 {
     private const string ProviderTypeName = "JustSaying.AsyncApi.IAsyncApiDocumentProvider";
     private const string ProviderAssemblyName = "JustSaying.AsyncApi";
+    private const string DefaultDocumentName = "asyncapi";
+    private const string TimeoutPropertyName = "JustSayingAsyncApiEntryPointTimeoutSeconds";
 
     private static readonly TimeSpan GenerationTimeout = TimeSpan.FromMinutes(2);
 
@@ -24,6 +27,8 @@ internal static class Program
         string? assemblyPath = null;
         string? outputDirectory = null;
         string? fileListPath = null;
+        string? fileName = null;
+        string? entryPointTimeout = null;
 
         for (var i = 0; i < args.Length - 1; i++)
         {
@@ -38,12 +43,34 @@ internal static class Program
                 case "--file-list":
                     fileListPath = args[++i];
                     break;
+                case "--file-name":
+                    fileName = args[++i];
+                    break;
+                case "--entry-point-timeout":
+                    entryPointTimeout = args[++i];
+                    break;
             }
         }
 
         if (assemblyPath is null || outputDirectory is null)
         {
-            return Error(1, "Usage: JustSaying.AsyncApi.GetDocument --assembly <path> --output <directory> [--file-list <path>]");
+            return Error(1, "Usage: JustSaying.AsyncApi.GetDocument --assembly <path> --output <directory> [--file-list <path>] [--file-name <name>] [--entry-point-timeout <seconds>]");
+        }
+
+        if (fileName is not null && !Regex.IsMatch(fileName, "^[A-Za-z0-9_.-]+$"))
+        {
+            return Error(1, $"The file name '{fileName}' is invalid. File names must contain only letters, digits, '.', '-' and '_'.");
+        }
+
+        TimeSpan? waitTimeout = null;
+        if (entryPointTimeout is not null)
+        {
+            if (!uint.TryParse(entryPointTimeout, out var timeoutSeconds) || timeoutSeconds == 0)
+            {
+                return Error(1, $"The entry point timeout '{entryPointTimeout}' is invalid. Specify a positive number of seconds.");
+            }
+
+            waitTimeout = TimeSpan.FromSeconds(timeoutSeconds);
         }
 
         Assembly assembly;
@@ -56,7 +83,7 @@ internal static class Program
             return Error(2, $"Failed to load the application assembly '{assemblyPath}': {exception.Message}");
         }
 
-        var serviceProviderFactory = HostFactoryResolver.ResolveServiceProviderFactory(assembly);
+        var serviceProviderFactory = HostFactoryResolver.ResolveServiceProviderFactory(assembly, waitTimeout);
         if (serviceProviderFactory is null)
         {
             return Error(3,
@@ -73,10 +100,21 @@ internal static class Program
         catch (Exception exception)
         {
             var reason = (exception as TargetInvocationException)?.InnerException ?? exception;
+
+            if (reason is InvalidOperationException && reason.Message.StartsWith("Timed out waiting for the entry point", StringComparison.Ordinal))
+            {
+                return Error(4,
+                    $"The entry point of '{assembly.GetName().Name}' did not build its host within {(waitTimeout ?? TimeSpan.FromMinutes(5)).TotalSeconds:0} seconds. " +
+                    $"If the application does slow work before building the host, raise the {TimeoutPropertyName} MSBuild property, " +
+                    "or skip that work during generation (the entry assembly is 'JustSaying.AsyncApi.GetDocument' while a document is generated).");
+            }
+
             return Error(4,
                 $"The entry point of '{assembly.GetName().Name}' threw while building the host: {reason.Message} " +
                 "The application's Program runs during document generation (its host is built but never started); " +
-                "it must be able to reach the host Build() call at build time.");
+                "it must be able to reach the host Build() call at build time. " +
+                "Note that the entry point is invoked with the arguments ['--applicationName', '<assembly name>'], " +
+                "and that the entry assembly is 'JustSaying.AsyncApi.GetDocument' while a document is generated.");
         }
 
         if (services is null)
@@ -111,7 +149,7 @@ internal static class Program
 
         try
         {
-            return GenerateDocuments(provider, getDocumentNames, generateAsync, outputDirectory, fileListPath);
+            return GenerateDocuments(provider, getDocumentNames, generateAsync, outputDirectory, fileListPath, fileName);
         }
         catch (Exception exception)
         {
@@ -125,14 +163,15 @@ internal static class Program
         MethodInfo getDocumentNames,
         MethodInfo generateAsync,
         string outputDirectory,
-        string? fileListPath)
+        string? fileListPath,
+        string? fileName)
     {
         Directory.CreateDirectory(outputDirectory);
 
         var generatedFiles = new List<string>();
         foreach (var documentName in (IEnumerable<string>)getDocumentNames.Invoke(provider, null)!)
         {
-            var filePath = Path.Combine(outputDirectory, SanitizeFileName(documentName) + ".json");
+            var filePath = Path.Combine(outputDirectory, GetDocumentFileName(documentName, fileName));
 
             using var writer = new StringWriter();
             var task = (Task)generateAsync.Invoke(provider, [documentName, writer, CancellationToken.None])!;
@@ -192,6 +231,20 @@ internal static class Program
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Names the output file. The default document keeps the configured file name alone
+    /// (<c>asyncapi.json</c>, or <c>MyProject.json</c> when the file name is overridden);
+    /// any additional documents are suffixed with the document name, mirroring
+    /// Microsoft.Extensions.ApiDescription.Server's naming.
+    /// </summary>
+    private static string GetDocumentFileName(string documentName, string? fileName)
+    {
+        fileName ??= DefaultDocumentName;
+        return string.Equals(documentName, DefaultDocumentName, StringComparison.Ordinal)
+            ? fileName + ".json"
+            : $"{fileName}_{SanitizeFileName(documentName)}.json";
     }
 
     private static string SanitizeFileName(string documentName)

--- a/src/JustSaying.AsyncApi.BuildTools/Program.cs
+++ b/src/JustSaying.AsyncApi.BuildTools/Program.cs
@@ -1,0 +1,215 @@
+using System.Reflection;
+using Microsoft.Extensions.Hosting;
+
+namespace JustSaying.AsyncApi.GetDocument;
+
+/// <summary>
+/// Entry point for build-time AsyncAPI document generation. The MSBuild targets in the
+/// JustSaying.AsyncApi.BuildTools package invoke this tool with
+/// <c>dotnet exec --depsfile {app}.deps.json --runtimeconfig {app}.runtimeconfig.json</c>,
+/// so the application's assemblies resolve exactly as if the application itself were running.
+/// The tool captures the application's host as it is built (the host is never started, so no
+/// hosted services run and no AWS calls are made), resolves JustSaying's document provider
+/// from the container by reflection, and writes each document to the output directory.
+/// </summary>
+internal static class Program
+{
+    private const string ProviderTypeName = "JustSaying.AsyncApi.IAsyncApiDocumentProvider";
+    private const string ProviderAssemblyName = "JustSaying.AsyncApi";
+
+    private static readonly TimeSpan GenerationTimeout = TimeSpan.FromMinutes(2);
+
+    public static int Main(string[] args)
+    {
+        string? assemblyPath = null;
+        string? outputDirectory = null;
+        string? fileListPath = null;
+
+        for (var i = 0; i < args.Length - 1; i++)
+        {
+            switch (args[i])
+            {
+                case "--assembly":
+                    assemblyPath = args[++i];
+                    break;
+                case "--output":
+                    outputDirectory = args[++i];
+                    break;
+                case "--file-list":
+                    fileListPath = args[++i];
+                    break;
+            }
+        }
+
+        if (assemblyPath is null || outputDirectory is null)
+        {
+            return Error(1, "Usage: JustSaying.AsyncApi.GetDocument --assembly <path> --output <directory> [--file-list <path>]");
+        }
+
+        Assembly assembly;
+        try
+        {
+            assembly = Assembly.Load(new AssemblyName(Path.GetFileNameWithoutExtension(assemblyPath)));
+        }
+        catch (Exception exception)
+        {
+            return Error(2, $"Failed to load the application assembly '{assemblyPath}': {exception.Message}");
+        }
+
+        var serviceProviderFactory = HostFactoryResolver.ResolveServiceProviderFactory(assembly);
+        if (serviceProviderFactory is null)
+        {
+            return Error(3,
+                $"The entry point of '{assembly.GetName().Name}' does not build a host, so its services cannot be discovered. " +
+                "Build-time AsyncAPI generation requires the application to use Host.CreateApplicationBuilder, WebApplication.CreateBuilder, " +
+                "or a static CreateHostBuilder(string[]) method on the Program class.");
+        }
+
+        IServiceProvider? services;
+        try
+        {
+            services = serviceProviderFactory([]);
+        }
+        catch (Exception exception)
+        {
+            var reason = (exception as TargetInvocationException)?.InnerException ?? exception;
+            return Error(4,
+                $"The entry point of '{assembly.GetName().Name}' threw while building the host: {reason.Message} " +
+                "The application's Program runs during document generation (its host is built but never started); " +
+                "it must be able to reach the host Build() call at build time.");
+        }
+
+        if (services is null)
+        {
+            return Error(4, $"The entry point of '{assembly.GetName().Name}' built a host, but no service provider could be obtained from it.");
+        }
+
+        var providerType = FindProviderType();
+        if (providerType is null)
+        {
+            return Error(5,
+                $"'{assembly.GetName().Name}' does not reference the {ProviderAssemblyName} package, which provides the document generator. " +
+                $"Add a reference to {ProviderAssemblyName} and call AddJustSayingAsyncApi() when configuring services.");
+        }
+
+        var provider = services.GetService(providerType);
+        if (provider is null)
+        {
+            return Error(6,
+                "No AsyncAPI document provider is registered with the application's service provider. " +
+                "Call AddJustSayingAsyncApi() when configuring the application's services.");
+        }
+
+        var getDocumentNames = providerType.GetMethod("GetDocumentNames", Type.EmptyTypes);
+        var generateAsync = providerType.GetMethod("GenerateAsync", [typeof(string), typeof(TextWriter), typeof(CancellationToken)]);
+        if (getDocumentNames is null || generateAsync is null || !typeof(IEnumerable<string>).IsAssignableFrom(getDocumentNames.ReturnType))
+        {
+            return Error(7,
+                $"The {ProviderTypeName} contract in the application's version of {ProviderAssemblyName} does not match this tool. " +
+                $"Update the {ProviderAssemblyName} and JustSaying.AsyncApi.BuildTools packages to the same version.");
+        }
+
+        try
+        {
+            return GenerateDocuments(provider, getDocumentNames, generateAsync, outputDirectory, fileListPath);
+        }
+        catch (Exception exception)
+        {
+            var reason = exception is AggregateException aggregate ? aggregate.Flatten().InnerException ?? exception : exception;
+            return Error(8, $"Generating the AsyncAPI document failed: {reason.Message}");
+        }
+    }
+
+    private static int GenerateDocuments(
+        object provider,
+        MethodInfo getDocumentNames,
+        MethodInfo generateAsync,
+        string outputDirectory,
+        string? fileListPath)
+    {
+        Directory.CreateDirectory(outputDirectory);
+
+        var generatedFiles = new List<string>();
+        foreach (var documentName in (IEnumerable<string>)getDocumentNames.Invoke(provider, null)!)
+        {
+            var filePath = Path.Combine(outputDirectory, SanitizeFileName(documentName) + ".json");
+
+            using var writer = new StringWriter();
+            var task = (Task)generateAsync.Invoke(provider, [documentName, writer, CancellationToken.None])!;
+            if (!task.Wait(GenerationTimeout))
+            {
+                return Error(9, $"Generating the AsyncAPI document '{documentName}' did not complete within {GenerationTimeout.TotalSeconds:0} seconds.");
+            }
+
+            // Leave the file untouched when the content has not changed so that its timestamp
+            // stays stable and a committed document does not show up as modified.
+            var content = writer.ToString();
+            if (!File.Exists(filePath) || !string.Equals(File.ReadAllText(filePath), content, StringComparison.Ordinal))
+            {
+                File.WriteAllText(filePath, content);
+                Console.WriteLine($"Generated AsyncAPI document '{documentName}' -> {filePath}");
+            }
+            else
+            {
+                Console.WriteLine($"AsyncAPI document '{documentName}' is up to date: {filePath}");
+            }
+
+            generatedFiles.Add(filePath);
+        }
+
+        if (fileListPath is not null)
+        {
+            var fileListDirectory = Path.GetDirectoryName(Path.GetFullPath(fileListPath));
+            if (!string.IsNullOrEmpty(fileListDirectory))
+            {
+                Directory.CreateDirectory(fileListDirectory);
+            }
+
+            File.WriteAllLines(fileListPath, generatedFiles);
+        }
+
+        return 0;
+    }
+
+    private static Type? FindProviderType()
+    {
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (assembly.GetType(ProviderTypeName, throwOnError: false) is { } type)
+            {
+                return type;
+            }
+        }
+
+        // The assembly may be referenced but not yet loaded if the application never called
+        // AddJustSayingAsyncApi(); loading it here distinguishes "not registered" (a better
+        // error) from "not referenced".
+        try
+        {
+            return Assembly.Load(ProviderAssemblyName).GetType(ProviderTypeName, throwOnError: false);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private static string SanitizeFileName(string documentName)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        return string.Create(documentName.Length, documentName, (buffer, name) =>
+        {
+            for (var i = 0; i < name.Length; i++)
+            {
+                buffer[i] = Array.IndexOf(invalid, name[i]) >= 0 ? '_' : name[i];
+            }
+        });
+    }
+
+    private static int Error(int exitCode, string message)
+    {
+        // The canonical MSBuild error format, so that Exec surfaces the message as a build error.
+        Console.Error.WriteLine($"JustSaying.AsyncApi.GetDocument : error JSAA{exitCode:000}: {message}");
+        return exitCode;
+    }
+}

--- a/src/JustSaying.AsyncApi.BuildTools/Program.cs
+++ b/src/JustSaying.AsyncApi.BuildTools/Program.cs
@@ -122,24 +122,24 @@ internal static class Program
             return Error(4, $"The entry point of '{assembly.GetName().Name}' built a host, but no service provider could be obtained from it.");
         }
 
-        var providerType = FindProviderType();
-        if (providerType is null)
+        var documentProviderType = FindDocumentProviderType();
+        if (documentProviderType is null)
         {
             return Error(5,
                 $"'{assembly.GetName().Name}' does not reference the {ProviderAssemblyName} package, which provides the document generator. " +
                 $"Add a reference to {ProviderAssemblyName} and call AddJustSayingAsyncApi() when configuring services.");
         }
 
-        var provider = services.GetService(providerType);
-        if (provider is null)
+        var documentProvider = services.GetService(documentProviderType);
+        if (documentProvider is null)
         {
             return Error(6,
                 "No AsyncAPI document provider is registered with the application's service provider. " +
                 "Call AddJustSayingAsyncApi() when configuring the application's services.");
         }
 
-        var getDocumentNames = providerType.GetMethod("GetDocumentNames", Type.EmptyTypes);
-        var generateAsync = providerType.GetMethod("GenerateAsync", [typeof(string), typeof(TextWriter), typeof(CancellationToken)]);
+        var getDocumentNames = documentProviderType.GetMethod("GetDocumentNames", Type.EmptyTypes);
+        var generateAsync = documentProviderType.GetMethod("GenerateAsync", [typeof(string), typeof(TextWriter), typeof(CancellationToken)]);
         if (getDocumentNames is null || generateAsync is null || !typeof(IEnumerable<string>).IsAssignableFrom(getDocumentNames.ReturnType))
         {
             return Error(7,
@@ -149,7 +149,7 @@ internal static class Program
 
         try
         {
-            return GenerateDocuments(provider, getDocumentNames, generateAsync, outputDirectory, fileListPath, fileName);
+            return GenerateDocuments(documentProvider, getDocumentNames, generateAsync, outputDirectory, fileListPath, fileName);
         }
         catch (Exception exception)
         {
@@ -159,7 +159,7 @@ internal static class Program
     }
 
     private static int GenerateDocuments(
-        object provider,
+        object documentProvider,
         MethodInfo getDocumentNames,
         MethodInfo generateAsync,
         string outputDirectory,
@@ -169,7 +169,7 @@ internal static class Program
         Directory.CreateDirectory(outputDirectory);
 
         var generatedFiles = new List<string>();
-        foreach (var documentName in (IEnumerable<string>)getDocumentNames.Invoke(provider, null)!)
+        foreach (var documentName in (IEnumerable<string>)getDocumentNames.Invoke(documentProvider, null)!)
         {
             var filePath = Path.Combine(outputDirectory, GetDocumentFileName(documentName, fileName));
 
@@ -177,7 +177,7 @@ internal static class Program
 
             // Generation runs synchronously up to its first await, so the call itself is made on
             // the worker task; invoking it here would leave that work outside the timeout.
-            var task = Task.Run(() => (Task)generateAsync.Invoke(provider, [documentName, writer, CancellationToken.None])!);
+            var task = Task.Run(() => (Task)generateAsync.Invoke(documentProvider, [documentName, writer, CancellationToken.None])!);
             if (!task.Wait(GenerationTimeout))
             {
                 return Error(9, $"Generating the AsyncAPI document '{documentName}' did not complete within {GenerationTimeout.TotalSeconds:0} seconds.");
@@ -213,7 +213,7 @@ internal static class Program
         return 0;
     }
 
-    private static Type? FindProviderType()
+    private static Type? FindDocumentProviderType()
     {
         foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
         {

--- a/src/JustSaying.AsyncApi.BuildTools/build/JustSaying.AsyncApi.BuildTools.props
+++ b/src/JustSaying.AsyncApi.BuildTools/build/JustSaying.AsyncApi.BuildTools.props
@@ -4,5 +4,18 @@
     <JustSayingAsyncApiGenerateDocumentsOnBuild Condition=" '$(JustSayingAsyncApiGenerateDocumentsOnBuild)' == '' ">true</JustSayingAsyncApiGenerateDocumentsOnBuild>
     <!-- The directory the generated documents are written to. -->
     <JustSayingAsyncApiDocumentsDirectory Condition=" '$(JustSayingAsyncApiDocumentsDirectory)' == '' ">$(MSBuildProjectDirectory)</JustSayingAsyncApiDocumentsDirectory>
+    <!--
+      The file name (without extension) of the generated document. When several projects share a
+      documents directory, give each a unique name — for example '$(MSBuildProjectName)', which
+      produces '<ProjectName>.json' per project instead of colliding on 'asyncapi.json'.
+    -->
+    <JustSayingAsyncApiDocumentFileName Condition=" '$(JustSayingAsyncApiDocumentFileName)' == '' ">asyncapi</JustSayingAsyncApiDocumentFileName>
+    <!--
+      How long document generation waits for the application's entry point to build its host
+      before failing the build. Applications that do slow work before building the host (for
+      example migrations or waiting on a dependency) can raise this, or skip that work when
+      generating: the entry assembly is 'JustSaying.AsyncApi.GetDocument' during generation.
+    -->
+    <JustSayingAsyncApiEntryPointTimeoutSeconds Condition=" '$(JustSayingAsyncApiEntryPointTimeoutSeconds)' == '' ">60</JustSayingAsyncApiEntryPointTimeoutSeconds>
   </PropertyGroup>
 </Project>

--- a/src/JustSaying.AsyncApi.BuildTools/build/JustSaying.AsyncApi.BuildTools.props
+++ b/src/JustSaying.AsyncApi.BuildTools/build/JustSaying.AsyncApi.BuildTools.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <!-- Set to 'false' to reference the package without generating documents on every build. -->
+    <JustSayingAsyncApiGenerateDocumentsOnBuild Condition=" '$(JustSayingAsyncApiGenerateDocumentsOnBuild)' == '' ">true</JustSayingAsyncApiGenerateDocumentsOnBuild>
+    <!-- The directory the generated documents are written to. -->
+    <JustSayingAsyncApiDocumentsDirectory Condition=" '$(JustSayingAsyncApiDocumentsDirectory)' == '' ">$(MSBuildProjectDirectory)</JustSayingAsyncApiDocumentsDirectory>
+  </PropertyGroup>
+</Project>

--- a/src/JustSaying.AsyncApi.BuildTools/build/JustSaying.AsyncApi.BuildTools.targets
+++ b/src/JustSaying.AsyncApi.BuildTools/build/JustSaying.AsyncApi.BuildTools.targets
@@ -1,0 +1,52 @@
+<Project>
+  <PropertyGroup>
+    <_JustSayingAsyncApiToolPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\tools\net8.0\JustSaying.AsyncApi.GetDocument.dll'))</_JustSayingAsyncApiToolPath>
+    <_JustSayingAsyncApiFileListPath>$(IntermediateOutputPath)JustSayingAsyncApi.cache</_JustSayingAsyncApiFileListPath>
+  </PropertyGroup>
+
+  <!--
+    Generates the application's AsyncAPI document(s) after every build, analogous to
+    Microsoft.Extensions.ApiDescription.Server's build-time OpenAPI generation. The tool runs
+    with the application's deps.json and runtimeconfig.json so the application's assemblies
+    resolve normally; the application's host is built (never started) to collect the configured
+    publications and subscriptions.
+  -->
+  <Target Name="GenerateJustSayingAsyncApiDocuments"
+          AfterTargets="Build"
+          Inputs="$(TargetPath);$(ProjectDepsFilePath);$(ProjectRuntimeConfigFilePath)"
+          Outputs="$(_JustSayingAsyncApiFileListPath)"
+          Condition=" '$(JustSayingAsyncApiGenerateDocumentsOnBuild)' == 'true' AND
+                      '$(DesignTimeBuild)' != 'true' AND
+                      '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
+                      $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0')) AND
+                      '$(OutputType)' == 'Exe' ">
+    <Error Condition=" !Exists('$(_JustSayingAsyncApiToolPath)') "
+           Text="The JustSaying AsyncAPI generation tool was not found at '$(_JustSayingAsyncApiToolPath)'. The JustSaying.AsyncApi.BuildTools package may be corrupt; try restoring again." />
+    <Error Condition=" !Exists('$(ProjectDepsFilePath)') "
+           Text="Build-time AsyncAPI generation requires a dependencies file ($(ProjectDepsFilePath)). Do not set GenerateDependencyFile to 'false', or set JustSayingAsyncApiGenerateDocumentsOnBuild to 'false' to disable generation." />
+
+    <PropertyGroup>
+      <_JustSayingAsyncApiCommand>dotnet exec --depsfile "$(ProjectDepsFilePath)" --runtimeconfig "$(ProjectRuntimeConfigFilePath)"</_JustSayingAsyncApiCommand>
+      <_JustSayingAsyncApiCommand Condition=" '$(NuGetPackageRoot)' != '' ">$(_JustSayingAsyncApiCommand) --additionalprobingpath "$(NuGetPackageRoot.TrimEnd('\').TrimEnd('/'))"</_JustSayingAsyncApiCommand>
+      <_JustSayingAsyncApiCommand>$(_JustSayingAsyncApiCommand) "$(_JustSayingAsyncApiToolPath)" --assembly "$(TargetPath)" --output "$(JustSayingAsyncApiDocumentsDirectory)" --file-list "$(_JustSayingAsyncApiFileListPath)"</_JustSayingAsyncApiCommand>
+    </PropertyGroup>
+
+    <!--
+      The tool reports its own failures in the canonical MSBuild error format, which Exec
+      surfaces as build errors; IgnoreExitCode avoids also dumping the whole command line as a
+      second error. The Error task below catches any failure where the tool could not report.
+    -->
+    <Exec Command="$(_JustSayingAsyncApiCommand)"
+          WorkingDirectory="$(TargetDir)"
+          StandardOutputImportance="normal"
+          IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="_JustSayingAsyncApiExitCode" />
+    </Exec>
+    <Error Condition=" '$(_JustSayingAsyncApiExitCode)' != '0' "
+           Text="AsyncAPI document generation for '$(MSBuildProjectName)' failed with exit code $(_JustSayingAsyncApiExitCode). Set JustSayingAsyncApiGenerateDocumentsOnBuild to 'false' to disable build-time generation." />
+
+    <ItemGroup>
+      <FileWrites Include="$(_JustSayingAsyncApiFileListPath)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/JustSaying.AsyncApi.BuildTools/build/JustSaying.AsyncApi.BuildTools.targets
+++ b/src/JustSaying.AsyncApi.BuildTools/build/JustSaying.AsyncApi.BuildTools.targets
@@ -5,21 +5,18 @@
   </PropertyGroup>
 
   <!--
-    Generates the application's AsyncAPI document(s) after every build, analogous to
+    Generates the application's AsyncAPI document(s), analogous to
     Microsoft.Extensions.ApiDescription.Server's build-time OpenAPI generation. The tool runs
     with the application's deps.json and runtimeconfig.json so the application's assemblies
     resolve normally; the application's host is built (never started) to collect the configured
     publications and subscriptions.
+
+    This target can also be invoked directly (dotnet msbuild -t:GenerateJustSayingAsyncApiDocuments),
+    for example when JustSayingAsyncApiGenerateDocumentsOnBuild is 'false'.
   -->
   <Target Name="GenerateJustSayingAsyncApiDocuments"
-          AfterTargets="Build"
           Inputs="$(TargetPath);$(ProjectDepsFilePath);$(ProjectRuntimeConfigFilePath)"
-          Outputs="$(_JustSayingAsyncApiFileListPath)"
-          Condition=" '$(JustSayingAsyncApiGenerateDocumentsOnBuild)' == 'true' AND
-                      '$(DesignTimeBuild)' != 'true' AND
-                      '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
-                      $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0')) AND
-                      '$(OutputType)' == 'Exe' ">
+          Outputs="$(_JustSayingAsyncApiFileListPath)">
     <Error Condition=" !Exists('$(_JustSayingAsyncApiToolPath)') "
            Text="The JustSaying AsyncAPI generation tool was not found at '$(_JustSayingAsyncApiToolPath)'. The JustSaying.AsyncApi.BuildTools package may be corrupt; try restoring again." />
     <Error Condition=" !Exists('$(ProjectDepsFilePath)') "
@@ -29,6 +26,8 @@
       <_JustSayingAsyncApiCommand>dotnet exec --depsfile "$(ProjectDepsFilePath)" --runtimeconfig "$(ProjectRuntimeConfigFilePath)"</_JustSayingAsyncApiCommand>
       <_JustSayingAsyncApiCommand Condition=" '$(NuGetPackageRoot)' != '' ">$(_JustSayingAsyncApiCommand) --additionalprobingpath "$(NuGetPackageRoot.TrimEnd('\').TrimEnd('/'))"</_JustSayingAsyncApiCommand>
       <_JustSayingAsyncApiCommand>$(_JustSayingAsyncApiCommand) "$(_JustSayingAsyncApiToolPath)" --assembly "$(TargetPath)" --output "$(JustSayingAsyncApiDocumentsDirectory)" --file-list "$(_JustSayingAsyncApiFileListPath)"</_JustSayingAsyncApiCommand>
+      <_JustSayingAsyncApiCommand Condition=" '$(JustSayingAsyncApiDocumentFileName)' != '' ">$(_JustSayingAsyncApiCommand) --file-name "$(JustSayingAsyncApiDocumentFileName)"</_JustSayingAsyncApiCommand>
+      <_JustSayingAsyncApiCommand Condition=" '$(JustSayingAsyncApiEntryPointTimeoutSeconds)' != '' ">$(_JustSayingAsyncApiCommand) --entry-point-timeout "$(JustSayingAsyncApiEntryPointTimeoutSeconds)"</_JustSayingAsyncApiCommand>
     </PropertyGroup>
 
     <!--
@@ -49,4 +48,22 @@
       <FileWrites Include="$(_JustSayingAsyncApiFileListPath)" />
     </ItemGroup>
   </Target>
+
+  <!--
+    Ties generation into every build. Multi-targeted projects are handled by the
+    buildMultiTargeting targets instead (one generation per build, not one per framework), so
+    this hook only applies when the project builds a single target framework. Test projects are
+    executables on modern test frameworks but are never JustSaying applications, so they are
+    excluded.
+  -->
+  <Target Name="_GenerateJustSayingAsyncApiDocumentsAfterBuild"
+          AfterTargets="Build"
+          DependsOnTargets="GenerateJustSayingAsyncApiDocuments"
+          Condition=" '$(JustSayingAsyncApiGenerateDocumentsOnBuild)' == 'true' AND
+                      '$(DesignTimeBuild)' != 'true' AND
+                      '$(IsTestProject)' != 'true' AND
+                      '$(TargetFrameworks)' == '' AND
+                      '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
+                      $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0')) AND
+                      '$(OutputType)' == 'Exe' " />
 </Project>

--- a/src/JustSaying.AsyncApi.BuildTools/buildMultiTargeting/JustSaying.AsyncApi.BuildTools.props
+++ b/src/JustSaying.AsyncApi.BuildTools/buildMultiTargeting/JustSaying.AsyncApi.BuildTools.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="../build/JustSaying.AsyncApi.BuildTools.props" />
+</Project>

--- a/src/JustSaying.AsyncApi.BuildTools/buildMultiTargeting/JustSaying.AsyncApi.BuildTools.targets
+++ b/src/JustSaying.AsyncApi.BuildTools/buildMultiTargeting/JustSaying.AsyncApi.BuildTools.targets
@@ -1,0 +1,35 @@
+<Project>
+  <!--
+    In a multi-targeted project the document is generated once per build rather than once per
+    target framework: the inner-build hook is disabled (see the build/ targets) and this outer
+    target invokes generation for the first target framework the tool supports (.NET 8+). The
+    document describes the application's messaging contract, which does not vary by framework.
+  -->
+  <Target Name="GenerateJustSayingAsyncApiDocuments">
+    <ItemGroup>
+      <_JustSayingAsyncApiTargetFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_JustSayingAsyncApiGenerationTargetFramework
+          Condition=" '$(_JustSayingAsyncApiGenerationTargetFramework)' == '' AND
+                      $([System.Text.RegularExpressions.Regex]::IsMatch('%(_JustSayingAsyncApiTargetFramework.Identity)', '^net(8|9|[1-9][0-9])\.')) ">%(_JustSayingAsyncApiTargetFramework.Identity)</_JustSayingAsyncApiGenerationTargetFramework>
+    </PropertyGroup>
+
+    <Message Importance="normal"
+             Condition=" '$(_JustSayingAsyncApiGenerationTargetFramework)' == '' "
+             Text="Skipping AsyncAPI document generation for '$(MSBuildProjectName)': none of the target frameworks ($(TargetFrameworks)) is .NET 8 or later." />
+    <MSBuild Condition=" '$(_JustSayingAsyncApiGenerationTargetFramework)' != '' "
+             Projects="$(MSBuildProjectFile)"
+             Targets="GenerateJustSayingAsyncApiDocuments"
+             Properties="TargetFramework=$(_JustSayingAsyncApiGenerationTargetFramework)"
+             RemoveProperties="RuntimeIdentifier" />
+  </Target>
+
+  <Target Name="_GenerateJustSayingAsyncApiDocumentsAfterBuild"
+          AfterTargets="Build"
+          DependsOnTargets="GenerateJustSayingAsyncApiDocuments"
+          Condition=" '$(JustSayingAsyncApiGenerateDocumentsOnBuild)' == 'true' AND
+                      '$(DesignTimeBuild)' != 'true' AND
+                      '$(IsTestProject)' != 'true' AND
+                      '$(OutputType)' == 'Exe' " />
+</Project>

--- a/src/JustSaying.AsyncApi.BuildTools/buildMultiTargeting/JustSaying.AsyncApi.BuildTools.targets
+++ b/src/JustSaying.AsyncApi.BuildTools/buildMultiTargeting/JustSaying.AsyncApi.BuildTools.targets
@@ -8,21 +8,29 @@
   <Target Name="GenerateJustSayingAsyncApiDocuments">
     <ItemGroup>
       <_JustSayingAsyncApiTargetFramework Include="$(TargetFrameworks)" />
+      <_JustSayingAsyncApiSupportedTargetFramework
+          Include="@(_JustSayingAsyncApiTargetFramework)"
+          Condition=" $([System.Text.RegularExpressions.Regex]::IsMatch('%(Identity)', '^net(8|9|[1-9][0-9])\.')) " />
     </ItemGroup>
     <PropertyGroup>
+      <_JustSayingAsyncApiSupportedTargetFrameworks>@(_JustSayingAsyncApiSupportedTargetFramework)</_JustSayingAsyncApiSupportedTargetFrameworks>
       <_JustSayingAsyncApiGenerationTargetFramework
-          Condition=" '$(_JustSayingAsyncApiGenerationTargetFramework)' == '' AND
-                      $([System.Text.RegularExpressions.Regex]::IsMatch('%(_JustSayingAsyncApiTargetFramework.Identity)', '^net(8|9|[1-9][0-9])\.')) ">%(_JustSayingAsyncApiTargetFramework.Identity)</_JustSayingAsyncApiGenerationTargetFramework>
+          Condition=" '$(_JustSayingAsyncApiSupportedTargetFrameworks)' != '' ">$(_JustSayingAsyncApiSupportedTargetFrameworks.Split(';')[0])</_JustSayingAsyncApiGenerationTargetFramework>
     </PropertyGroup>
 
     <Message Importance="normal"
              Condition=" '$(_JustSayingAsyncApiGenerationTargetFramework)' == '' "
              Text="Skipping AsyncAPI document generation for '$(MSBuildProjectName)': none of the target frameworks ($(TargetFrameworks)) is .NET 8 or later." />
+    <!--
+      The runtime identifier (and any other global properties, such as SelfContained) flow
+      through to the inner invocation so it evaluates the same output paths the outer build
+      just produced: an outer build with a runtime identifier only builds RID-specific
+      outputs, so dropping it here would point generation at files that were never built.
+    -->
     <MSBuild Condition=" '$(_JustSayingAsyncApiGenerationTargetFramework)' != '' "
              Projects="$(MSBuildProjectFile)"
              Targets="GenerateJustSayingAsyncApiDocuments"
-             Properties="TargetFramework=$(_JustSayingAsyncApiGenerationTargetFramework)"
-             RemoveProperties="RuntimeIdentifier" />
+             Properties="TargetFramework=$(_JustSayingAsyncApiGenerationTargetFramework)" />
   </Target>
 
   <Target Name="_GenerateJustSayingAsyncApiDocumentsAfterBuild"

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 namespace JustSaying.AsyncApi;
 
 /// <summary>
-/// Generates an AsyncAPI 3.1 document from the publications and subscriptions captured in an
+/// Generates an AsyncAPI 3.0 document from the publications and subscriptions captured in an
 /// <see cref="IMessagingMetadataRegistry"/>.
 /// </summary>
 public sealed class AsyncApiDocumentGenerator

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
@@ -17,11 +17,21 @@ public sealed class AsyncApiDocumentGenerator
 {
     private const string CloudEventsContentType = "application/cloudevents+json";
 
+    private const string JsonContentType = "application/json";
+
     private readonly IMessagingMetadataRegistry _registry;
     private readonly AsyncApiOptions _options;
     private readonly IMessageBodySerializationFactory _serializationFactory;
-    private readonly CloudEventOptions _cloudEventOptions;
     private readonly ILogger<AsyncApiDocumentGenerator> _logger;
+    private readonly object _syncRoot = new();
+
+    // Per-generation state: each registration is described once, and the serializer-derived
+    // schema options and non-System.Text.Json warnings are computed once per serializer.
+    private readonly Dictionary<MessageTypeMetadata, MessageDescription> _descriptions = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<JsonSerializerOptions, JsonSerializerOptions> _schemaOptions = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Type> _undescribableSerializers = [];
+    private JsonSerializerOptions _fallbackSchemaOptions;
+    private bool _fallbackSchemaOptionsResolved;
 
     static AsyncApiDocumentGenerator()
     {
@@ -39,8 +49,11 @@ public sealed class AsyncApiDocumentGenerator
     /// </summary>
     /// <param name="registry">The registry of captured publications and subscriptions.</param>
     /// <param name="options">The options configuring the generated document.</param>
-    /// <param name="serializationFactory">The message body serialization factory in use, used to discover the payload wire contract.</param>
-    /// <param name="cloudEventOptions">The CloudEvents options, when CloudEvents support is configured.</param>
+    /// <param name="serializationFactory">
+    /// The app-wide message body serialization factory, used to discover the payload wire contract of a
+    /// registration whose own serializer was not captured. Each captured registration is described from
+    /// the serializer it actually uses (see <see cref="MessageTypeMetadata.Serializer"/>).
+    /// </param>
     /// <param name="logger">The logger used to surface why parts of the document are omitted.</param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="registry"/> or <paramref name="options"/> is <see langword="null"/>.
@@ -49,13 +62,11 @@ public sealed class AsyncApiDocumentGenerator
         IMessagingMetadataRegistry registry,
         AsyncApiOptions options,
         IMessageBodySerializationFactory serializationFactory = null,
-        CloudEventOptions cloudEventOptions = null,
         ILogger<AsyncApiDocumentGenerator> logger = null)
     {
         _registry = registry ?? throw new ArgumentNullException(nameof(registry));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _serializationFactory = serializationFactory;
-        _cloudEventOptions = cloudEventOptions;
         _logger = logger;
     }
 
@@ -64,6 +75,16 @@ public sealed class AsyncApiDocumentGenerator
     /// </summary>
     /// <returns>The generated <see cref="AsyncApiDocument"/>.</returns>
     public AsyncApiDocument Generate()
+    {
+        // The per-serializer caches are shared across generations, so serialize them: generation is
+        // rare (build time or a documentation request), and the registry is immutable by then.
+        lock (_syncRoot)
+        {
+            return GenerateCore();
+        }
+    }
+
+    private AsyncApiDocument GenerateCore()
     {
         var document = new AsyncApiDocument()
         {
@@ -74,7 +95,7 @@ public sealed class AsyncApiDocumentGenerator
                 Version = _options.Version,
                 Description = _options.Description,
             },
-            DefaultContentType = _cloudEventOptions != null ? CloudEventsContentType : "application/json",
+            DefaultContentType = JsonContentType,
         };
 
         string primaryRegion = PrimaryRegion();
@@ -88,7 +109,6 @@ public sealed class AsyncApiDocumentGenerator
                 "If the application does configure messaging, ensure AddJustSaying ran in the same service collection before the document was generated.");
         }
 
-        var serializerOptions = ResolveSerializerOptions();
         var channels = new Dictionary<string, ChannelState>(StringComparer.Ordinal);
         var operationMessages = new Dictionary<string, List<MessageTypeMetadata>>(StringComparer.Ordinal);
         var envelopeOperations = new HashSet<string>(StringComparer.Ordinal);
@@ -112,8 +132,7 @@ public sealed class AsyncApiDocumentGenerator
                 publication.DestinationKind,
                 publication.Region ?? _registry.Region,
                 $"The {publication.DestinationName} {(publication.DestinationKind == MessagingDestinationKind.SnsTopic ? "SNS topic" : "SQS queue")}.",
-                publication.Messages,
-                serializerOptions);
+                publication.Messages);
 
             // Several publications can target the same destination with different message
             // types; the operation is rebuilt from the merged set so none are dropped.
@@ -149,8 +168,7 @@ public sealed class AsyncApiDocumentGenerator
                 MessagingDestinationKind.SqsQueue,
                 subscription.Region ?? _registry.Region,
                 description,
-                subscription.Messages,
-                serializerOptions);
+                subscription.Messages);
 
             string operationKey = Sanitize($"receive-{channel.Key}");
             var merged = MergeOperationMessages(operationMessages, operationKey, subscription.Messages);
@@ -163,6 +181,14 @@ public sealed class AsyncApiDocumentGenerator
                 Description = DeliveryDescription(subscription),
                 Messages = [.. merged.Select((m) => new AsyncApiMessageReference($"#/channels/{channel.Key}/messages/{channel.MessageKeys[WireName(m)]}"))],
             };
+        }
+
+        // Every message states its own content type; the document-level default is only a
+        // convenience for readers, so it reflects the one format in use when there is one.
+        var contentTypes = _descriptions.Values.Select((d) => d.ContentType).Distinct(StringComparer.Ordinal).ToList();
+        if (contentTypes.Count == 1)
+        {
+            document.DefaultContentType = contentTypes[0];
         }
 
         _options.PostProcess?.Invoke(document);
@@ -252,8 +278,7 @@ public sealed class AsyncApiDocumentGenerator
         MessagingDestinationKind kind,
         string region,
         string description,
-        IReadOnlyList<MessageTypeMetadata> messages,
-        JsonSerializerOptions serializerOptions)
+        IReadOnlyList<MessageTypeMetadata> messages)
     {
         var identity = new ChannelIdentity(address, kind, region);
         string kindSuffix = kind == MessagingDestinationKind.SnsTopic ? "topic" : "queue";
@@ -305,7 +330,7 @@ public sealed class AsyncApiDocumentGenerator
                 state.MessageKeys[wireName] = messageKey;
             }
 
-            state.Channel.Messages[messageKey] = CreateMessage(message, serializerOptions);
+            state.Channel.Messages[messageKey] = CreateMessage(message);
         }
 
         return state;
@@ -384,31 +409,78 @@ public sealed class AsyncApiDocumentGenerator
             : "The topic subscription does not use raw message delivery: the SQS message body is the Amazon SNS notification envelope, and the documented message payload is the JSON-encoded string in its \"Message\" property.";
     }
 
-    private AsyncApiMessage CreateMessage(MessageTypeMetadata metadata, JsonSerializerOptions serializerOptions)
+    private AsyncApiMessage CreateMessage(MessageTypeMetadata metadata)
     {
-        string name = WireName(metadata);
+        var description = Describe(metadata);
 
         var message = new AsyncApiMessage()
         {
-            Name = name,
-            Title = FriendlyTypeName(metadata.MessageType),
-            ContentType = _cloudEventOptions != null ? CloudEventsContentType : "application/json",
+            Name = description.WireName,
+            Title = FriendlyTypeName(description.PayloadType),
+            ContentType = description.ContentType,
         };
 
-        var payloadSchema = ExportPayloadSchema(metadata.MessageType, serializerOptions);
-
-        if (_cloudEventOptions != null)
+        if (description.Payload != null)
         {
-            // The wire format is the CloudEvents structured-mode envelope with the message under
-            // "data"; documenting the bare message schema would hand consumers the wrong shape.
-            message.Payload = CreateCloudEventEnvelopeSchema(metadata, payloadSchema);
-        }
-        else if (payloadSchema != null)
-        {
-            message.Payload = payloadSchema;
+            message.Payload = description.Payload;
         }
 
         return message;
+    }
+
+    /// <summary>
+    /// How a registration's message appears on the wire: the name it is identified by, the CLR
+    /// type readers know it as, and the content type and schema of the body.
+    /// </summary>
+    private sealed record MessageDescription(string WireName, Type PayloadType, string ContentType, AsyncApiJsonSchema Payload);
+
+    private string WireName(MessageTypeMetadata metadata) => Describe(metadata).WireName;
+
+    /// <summary>
+    /// Describes a registration from the serializer it actually uses. Serialization is configured
+    /// per registration, so this — not any application-wide setting — is what determines whether a
+    /// message is plain JSON or a CloudEvents envelope, and which options shape its schema.
+    /// </summary>
+    private MessageDescription Describe(MessageTypeMetadata metadata)
+    {
+        if (_descriptions.TryGetValue(metadata, out var description))
+        {
+            return description;
+        }
+
+        var body = DescribeBody(metadata.MessageType, metadata.Serializer);
+
+        // A CloudEvent is identified by its `type`; anything else by its registered logical name.
+        string wireName = (metadata.Serializer as ICloudEventMessageBodySerializer)?.Type
+            ?? metadata.WireName
+            ?? metadata.MessageType.Name;
+
+        description = new MessageDescription(wireName, body.PayloadType, body.ContentType, body.Payload);
+        _descriptions[metadata] = description;
+        return description;
+    }
+
+    private (Type PayloadType, string ContentType, AsyncApiJsonSchema Payload) DescribeBody(Type messageType, object serializer)
+    {
+        switch (serializer)
+        {
+            case ICloudEventMessageBodySerializer cloudEvent:
+                // The wire format is the CloudEvents structured-mode envelope with the payload under
+                // "data"; documenting the bare payload schema would hand consumers the wrong shape.
+                // Whether the handler sees the envelope or just the data is the same on the wire.
+                var data = DescribeBody(cloudEvent.DataType, cloudEvent.DataSerializer);
+                return (cloudEvent.DataType, CloudEventsContentType, CreateCloudEventEnvelopeSchema(cloudEvent, data.Payload));
+
+            case ISystemTextJsonMessageBodySerializer systemTextJson:
+                return (messageType, JsonContentType, ExportPayloadSchema(messageType, SchemaOptions(systemTextJson.SerializerOptions)));
+
+            case null:
+                // The registration's serializer was not captured; fall back to the app-wide factory.
+                return (messageType, JsonContentType, ExportPayloadSchema(messageType, FallbackSchemaOptions()));
+
+            default:
+                return (messageType, JsonContentType, ExportPayloadSchema(messageType, UndescribableSerializerSchemaOptions(serializer)));
+        }
     }
 
     private AsyncApiJsonSchema ExportPayloadSchema(Type messageType, JsonSerializerOptions serializerOptions)
@@ -438,20 +510,26 @@ public sealed class AsyncApiDocumentGenerator
         }
     }
 
-    private AsyncApiJsonSchema CreateCloudEventEnvelopeSchema(MessageTypeMetadata metadata, AsyncApiJsonSchema dataSchema)
+    private static AsyncApiJsonSchema CreateCloudEventEnvelopeSchema(ICloudEventMessageBodySerializer serializer, AsyncApiJsonSchema dataSchema)
     {
         var typeSchema = new AsyncApiJsonSchema() { Type = SchemaType.String };
-        if (_cloudEventOptions.TryGetCloudEventType(metadata.MessageType, out var cloudEventType))
+        if (serializer.Type != null)
         {
-            typeSchema.Const = new AsyncApiAny(cloudEventType);
+            typeSchema.Const = new AsyncApiAny(serializer.Type);
         }
 
-        // Mirrors the envelope written by CloudEventMessageBodySerializer. Additional properties
-        // stay allowed so that CloudEvents extension attributes remain valid.
+        var dataContentTypeSchema = new AsyncApiJsonSchema() { Type = SchemaType.String };
+        if (serializer.DataContentType != null)
+        {
+            dataContentTypeSchema.Const = new AsyncApiAny(serializer.DataContentType);
+        }
+
+        // Mirrors the envelope written by the CloudEvents serializers. Additional properties stay
+        // allowed so that CloudEvents extension attributes remain valid.
         return new AsyncApiJsonSchema()
         {
             Type = SchemaType.Object,
-            Description = $"A CloudEvents 1.0 structured-mode JSON envelope carrying {FriendlyTypeName(metadata.MessageType)} in its \"data\" member.",
+            Description = $"A CloudEvents 1.0 structured-mode JSON envelope carrying {FriendlyTypeName(serializer.DataType)} in its \"data\" member.",
             Properties = new Dictionary<string, AsyncApiJsonSchema>(StringComparer.Ordinal)
             {
                 ["specversion"] = new() { Type = SchemaType.String, Const = new AsyncApiAny("1.0") },
@@ -459,58 +537,38 @@ public sealed class AsyncApiDocumentGenerator
                 ["source"] = new() { Type = SchemaType.String, Format = "uri-reference" },
                 ["type"] = typeSchema,
                 ["time"] = new() { Type = SchemaType.String, Format = "date-time" },
-                ["datacontenttype"] = new() { Type = SchemaType.String },
+                ["datacontenttype"] = dataContentTypeSchema,
+                ["subject"] = new() { Type = SchemaType.String },
                 ["data"] = dataSchema ?? new AsyncApiJsonSchema(),
             },
             Required = new HashSet<string>(StringComparer.Ordinal) { "specversion", "id", "source", "type", "data" },
         };
     }
 
-    private string WireName(MessageTypeMetadata metadata)
+    /// <summary>
+    /// The options to export schemas with for a System.Text.Json serializer, honouring an explicit
+    /// <see cref="AsyncApiOptions.SerializerOptions"/> override and ensuring a type info resolver.
+    /// </summary>
+    private JsonSerializerOptions SchemaOptions(JsonSerializerOptions serializerOptions)
     {
-        if (_cloudEventOptions != null && _cloudEventOptions.TryGetCloudEventType(metadata.MessageType, out var cloudEventType))
+        if (_options.SerializerOptions != null)
         {
-            return cloudEventType;
+            serializerOptions = _options.SerializerOptions;
         }
 
-        return metadata.WireName ?? metadata.MessageType.Name;
-    }
-
-    private JsonSerializerOptions ResolveSerializerOptions()
-    {
-        var options = _options.SerializerOptions;
-
-        if (options == null)
+        if (serializerOptions == null)
         {
-            var factory = _serializationFactory;
-            if (factory is CloudEventSerializationFactory cloudEventFactory)
-            {
-                factory = cloudEventFactory.DataSerializerFactory;
-            }
-
-            options = factory switch
-            {
-                SystemTextJsonSerializationFactory systemTextJsonFactory => systemTextJsonFactory.SerializerOptions,
-                null => SystemTextJsonMessageBodySerializer.DefaultJsonSerializerOptions,
-                // A Newtonsoft or custom factory's wire contract cannot be derived from
-                // System.Text.Json options (for example, JustSaying's Newtonsoft serializer
-                // writes enums as strings), so rather than documenting a schema that may not
-                // match the wire format, messages are documented without payload schemas
-                // unless AsyncApiOptions.SerializerOptions is supplied explicitly.
-                _ => null,
-            };
-
-            if (options == null)
-            {
-                _logger?.LogWarning(
-                    "The message body serialization factory ({SerializationFactory}) is not System.Text.Json-based, so the wire contract cannot be derived and messages are documented without payload schemas. " +
-                    "Set AsyncApiOptions.SerializerOptions to options matching the wire format to document payload schemas.",
-                    factory.GetType());
-                return null;
-            }
+            return null;
         }
 
-        if (options.TypeInfoResolver == null)
+        if (_schemaOptions.TryGetValue(serializerOptions, out var schemaOptions))
+        {
+            return schemaOptions;
+        }
+
+        schemaOptions = serializerOptions;
+
+        if (serializerOptions.TypeInfoResolver == null)
         {
             // The schema exporter requires a resolver to be set explicitly; the serializers rely on
             // it being applied lazily. Under Native AOT there is no reflection resolver to fall back
@@ -520,22 +578,84 @@ public sealed class AsyncApiDocumentGenerator
                 _logger?.LogWarning(
                     "Reflection-based serialization is disabled and the serializer options have no TypeInfoResolver, so messages are documented without payload schemas. " +
                     "Use serializer options with a source-generated JsonSerializerContext to document payload schemas.");
-                return null;
+                schemaOptions = null;
             }
-
-#pragma warning disable IL2026, IL3050
-            options = new JsonSerializerOptions(options)
+            else
             {
-                TypeInfoResolver = JsonSerializerOptions.Default.TypeInfoResolver,
-            };
+#pragma warning disable IL2026, IL3050
+                schemaOptions = new JsonSerializerOptions(serializerOptions)
+                {
+                    TypeInfoResolver = JsonSerializerOptions.Default.TypeInfoResolver,
+                };
 #pragma warning restore IL2026, IL3050
+            }
         }
 
-        return options;
+        _schemaOptions[serializerOptions] = schemaOptions;
+        return schemaOptions;
+    }
+
+    /// <summary>
+    /// A Newtonsoft or custom serializer's wire contract cannot be derived from System.Text.Json
+    /// options (for example, JustSaying's Newtonsoft serializer writes enums as strings), so rather
+    /// than documenting a schema that may not match the wire format, its messages are documented
+    /// without payload schemas unless <see cref="AsyncApiOptions.SerializerOptions"/> is supplied.
+    /// </summary>
+    private JsonSerializerOptions UndescribableSerializerSchemaOptions(object serializer)
+    {
+        if (_options.SerializerOptions != null)
+        {
+            return SchemaOptions(_options.SerializerOptions);
+        }
+
+        if (_undescribableSerializers.Add(serializer.GetType()))
+        {
+            _logger?.LogWarning(
+                "The message body serializer ({Serializer}) is not System.Text.Json-based, so the wire contract cannot be derived and its messages are documented without payload schemas. " +
+                "Set AsyncApiOptions.SerializerOptions to options matching the wire format to document payload schemas.",
+                serializer.GetType());
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The options to export schemas with for a registration whose serializer was not captured,
+    /// derived from the app-wide serialization factory.
+    /// </summary>
+    private JsonSerializerOptions FallbackSchemaOptions()
+    {
+        if (_fallbackSchemaOptionsResolved)
+        {
+            return _fallbackSchemaOptions;
+        }
+
+        _fallbackSchemaOptionsResolved = true;
+
+        if (_options.SerializerOptions != null)
+        {
+            return _fallbackSchemaOptions = SchemaOptions(_options.SerializerOptions);
+        }
+
+        switch (_serializationFactory)
+        {
+            case SystemTextJsonSerializationFactory systemTextJsonFactory:
+                return _fallbackSchemaOptions = SchemaOptions(systemTextJsonFactory.SerializerOptions);
+
+            case null:
+                return _fallbackSchemaOptions = SchemaOptions(SystemTextJsonMessageBodySerializer.DefaultJsonSerializerOptions);
+
+            default:
+                _logger?.LogWarning(
+                    "The message body serialization factory ({SerializationFactory}) is not System.Text.Json-based, so the wire contract cannot be derived and messages are documented without payload schemas. " +
+                    "Set AsyncApiOptions.SerializerOptions to options matching the wire format to document payload schemas.",
+                    _serializationFactory.GetType());
+                return null;
+        }
     }
 
     private string Join(IReadOnlyList<MessageTypeMetadata> messages)
-        => string.Join(", ", messages.Select((m) => FriendlyTypeName(m.MessageType)));
+        => string.Join(", ", messages.Select((m) => FriendlyTypeName(Describe(m).PayloadType)).Distinct(StringComparer.Ordinal));
 
     /// <summary>
     /// Renders a type name for display, expanding closed generics (for example

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
@@ -5,11 +5,12 @@ using ByteBard.AsyncAPI.Models;
 using JustSaying.CloudEvents;
 using JustSaying.Messaging.MessageSerialization;
 using JustSaying.Messaging.Metadata;
+using Microsoft.Extensions.Logging;
 
 namespace JustSaying.AsyncApi;
 
 /// <summary>
-/// Generates an AsyncAPI 3.0 document from the publications and subscriptions captured in an
+/// Generates an AsyncAPI 3.1 document from the publications and subscriptions captured in an
 /// <see cref="IMessagingMetadataRegistry"/>.
 /// </summary>
 public sealed class AsyncApiDocumentGenerator
@@ -20,6 +21,18 @@ public sealed class AsyncApiDocumentGenerator
     private readonly AsyncApiOptions _options;
     private readonly IMessageBodySerializationFactory _serializationFactory;
     private readonly CloudEventOptions _cloudEventOptions;
+    private readonly ILogger<AsyncApiDocumentGenerator> _logger;
+
+    static AsyncApiDocumentGenerator()
+    {
+        // ByteBard's writer materializes these enum arrays reflectively (Enum.GetValues, which
+        // calls Array.CreateInstance): SchemaType[] for every schema "type" keyword and
+        // ReferenceType[] when parsing "#/components/..." references. A Native AOT image only
+        // contains array types that are constructed statically somewhere, so construct them
+        // here or the writer throws NotSupportedException at runtime under Native AOT.
+        _ = Enum.GetValues<SchemaType>();
+        _ = Enum.GetValues<ReferenceType>();
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AsyncApiDocumentGenerator"/> class.
@@ -28,6 +41,7 @@ public sealed class AsyncApiDocumentGenerator
     /// <param name="options">The options configuring the generated document.</param>
     /// <param name="serializationFactory">The message body serialization factory in use, used to discover the payload wire contract.</param>
     /// <param name="cloudEventOptions">The CloudEvents options, when CloudEvents support is configured.</param>
+    /// <param name="logger">The logger used to surface why parts of the document are omitted.</param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="registry"/> or <paramref name="options"/> is <see langword="null"/>.
     /// </exception>
@@ -35,12 +49,14 @@ public sealed class AsyncApiDocumentGenerator
         IMessagingMetadataRegistry registry,
         AsyncApiOptions options,
         IMessageBodySerializationFactory serializationFactory = null,
-        CloudEventOptions cloudEventOptions = null)
+        CloudEventOptions cloudEventOptions = null,
+        ILogger<AsyncApiDocumentGenerator> logger = null)
     {
         _registry = registry ?? throw new ArgumentNullException(nameof(registry));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _serializationFactory = serializationFactory;
         _cloudEventOptions = cloudEventOptions;
+        _logger = logger;
     }
 
     /// <summary>
@@ -65,6 +81,14 @@ public sealed class AsyncApiDocumentGenerator
 
         AddServers(document, primaryRegion);
 
+        if (_registry.Publications.Count == 0 && _registry.Subscriptions.Count == 0)
+        {
+            _logger?.LogWarning(
+                "The generated AsyncAPI document is empty: no publications or subscriptions were captured. " +
+                "If the application does configure messaging, ensure AddJustSaying ran in the same service collection before the document was generated.");
+        }
+
+        var serializerOptions = ResolveSerializerOptions();
         var channels = new Dictionary<string, ChannelState>(StringComparer.Ordinal);
         var operationMessages = new Dictionary<string, List<MessageTypeMetadata>>(StringComparer.Ordinal);
 
@@ -73,6 +97,9 @@ public sealed class AsyncApiDocumentGenerator
             if (publication.IsDynamic)
             {
                 // A dynamic destination has no static address; there is no channel to document.
+                _logger?.LogWarning(
+                    "Publication of {MessageTypes} uses a dynamic destination name computed per message, so it has no static address and is omitted from the AsyncAPI document.",
+                    Join(publication.Messages));
                 continue;
             }
 
@@ -84,7 +111,8 @@ public sealed class AsyncApiDocumentGenerator
                 publication.DestinationKind,
                 publication.Region ?? _registry.Region,
                 $"The {publication.DestinationName} {(publication.DestinationKind == MessagingDestinationKind.SnsTopic ? "SNS topic" : "SQS queue")}.",
-                publication.Messages);
+                publication.Messages,
+                serializerOptions);
 
             // Several publications can target the same destination with different message
             // types; the operation is rebuilt from the merged set so none are dropped.
@@ -114,7 +142,8 @@ public sealed class AsyncApiDocumentGenerator
                 MessagingDestinationKind.SqsQueue,
                 subscription.Region ?? _registry.Region,
                 description,
-                subscription.Messages);
+                subscription.Messages,
+                serializerOptions);
 
             string operationKey = Sanitize($"receive-{channel.Key}");
             var merged = MergeOperationMessages(operationMessages, operationKey, subscription.Messages);
@@ -124,6 +153,7 @@ public sealed class AsyncApiDocumentGenerator
                 Action = AsyncApiAction.Receive,
                 Channel = new AsyncApiChannelReference($"#/channels/{channel.Key}"),
                 Summary = $"Receive {Join(merged)} from {subscription.QueueName}.",
+                Description = DeliveryDescription(subscription),
                 Messages = [.. merged.Select((m) => new AsyncApiMessageReference($"#/channels/{channel.Key}/messages/{channel.MessageKeys[WireName(m)]}"))],
             };
         }
@@ -215,7 +245,8 @@ public sealed class AsyncApiDocumentGenerator
         MessagingDestinationKind kind,
         string region,
         string description,
-        IReadOnlyList<MessageTypeMetadata> messages)
+        IReadOnlyList<MessageTypeMetadata> messages,
+        JsonSerializerOptions serializerOptions)
     {
         var identity = new ChannelIdentity(address, kind, region);
         string kindSuffix = kind == MessagingDestinationKind.SnsTopic ? "topic" : "queue";
@@ -267,7 +298,7 @@ public sealed class AsyncApiDocumentGenerator
                 state.MessageKeys[wireName] = messageKey;
             }
 
-            state.Channel.Messages[messageKey] = CreateMessage(message);
+            state.Channel.Messages[messageKey] = CreateMessage(message, serializerOptions);
         }
 
         return state;
@@ -319,36 +350,103 @@ public sealed class AsyncApiDocumentGenerator
         return merged;
     }
 
-    private AsyncApiMessage CreateMessage(MessageTypeMetadata metadata)
+    /// <summary>
+    /// Describes how documented payloads actually arrive on the queue. Without raw message
+    /// delivery, SNS wraps each message in its notification envelope, so the SQS body is not
+    /// the documented payload itself.
+    /// </summary>
+    private static string DeliveryDescription(SubscriptionMetadata subscription)
+    {
+        if (subscription.TopicName == null)
+        {
+            return null;
+        }
+
+        return subscription.RawMessageDelivery
+            ? "The topic subscription uses raw message delivery: the SQS message body is the documented message payload."
+            : "The topic subscription does not use raw message delivery: the SQS message body is the Amazon SNS notification envelope, and the documented message payload is the JSON-encoded string in its \"Message\" property.";
+    }
+
+    private AsyncApiMessage CreateMessage(MessageTypeMetadata metadata, JsonSerializerOptions serializerOptions)
     {
         string name = WireName(metadata);
 
         var message = new AsyncApiMessage()
         {
             Name = name,
-            Title = metadata.MessageType.Name,
+            Title = FriendlyTypeName(metadata.MessageType),
             ContentType = _cloudEventOptions != null ? CloudEventsContentType : "application/json",
         };
 
-        var serializerOptions = ResolveSerializerOptions();
-        if (serializerOptions != null)
-        {
-            try
-            {
-                var schemaNode = serializerOptions.GetJsonSchemaAsNode(metadata.MessageType, new JsonSchemaExporterOptions
-                {
-                    TreatNullObliviousAsNonNullable = true,
-                });
+        var payloadSchema = ExportPayloadSchema(metadata.MessageType, serializerOptions);
 
-                message.Payload = JsonSchemaNodeMapper.Map(schemaNode);
-            }
-            catch (NotSupportedException)
-            {
-                // The serializer cannot describe this type; the message is documented without a payload schema.
-            }
+        if (_cloudEventOptions != null)
+        {
+            // The wire format is the CloudEvents structured-mode envelope with the message under
+            // "data"; documenting the bare message schema would hand consumers the wrong shape.
+            message.Payload = CreateCloudEventEnvelopeSchema(metadata, payloadSchema);
+        }
+        else if (payloadSchema != null)
+        {
+            message.Payload = payloadSchema;
         }
 
         return message;
+    }
+
+    private AsyncApiJsonSchema ExportPayloadSchema(Type messageType, JsonSerializerOptions serializerOptions)
+    {
+        if (serializerOptions == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var schemaNode = serializerOptions.GetJsonSchemaAsNode(messageType, new JsonSchemaExporterOptions
+            {
+                TreatNullObliviousAsNonNullable = true,
+            });
+
+            return JsonSchemaNodeMapper.Map(schemaNode);
+        }
+        catch (NotSupportedException exception)
+        {
+            // The serializer cannot describe this type; the message is documented without a payload schema.
+            _logger?.LogWarning(
+                "A payload schema for message type {MessageType} could not be derived ({Reason}); the message is documented without one.",
+                messageType,
+                exception.Message);
+            return null;
+        }
+    }
+
+    private AsyncApiJsonSchema CreateCloudEventEnvelopeSchema(MessageTypeMetadata metadata, AsyncApiJsonSchema dataSchema)
+    {
+        var typeSchema = new AsyncApiJsonSchema() { Type = SchemaType.String };
+        if (_cloudEventOptions.TryGetCloudEventType(metadata.MessageType, out var cloudEventType))
+        {
+            typeSchema.Const = new AsyncApiAny(cloudEventType);
+        }
+
+        // Mirrors the envelope written by CloudEventMessageBodySerializer. Additional properties
+        // stay allowed so that CloudEvents extension attributes remain valid.
+        return new AsyncApiJsonSchema()
+        {
+            Type = SchemaType.Object,
+            Description = $"A CloudEvents 1.0 structured-mode JSON envelope carrying {FriendlyTypeName(metadata.MessageType)} in its \"data\" member.",
+            Properties = new Dictionary<string, AsyncApiJsonSchema>(StringComparer.Ordinal)
+            {
+                ["specversion"] = new() { Type = SchemaType.String, Const = new AsyncApiAny("1.0") },
+                ["id"] = new() { Type = SchemaType.String, MinLength = 1 },
+                ["source"] = new() { Type = SchemaType.String, Format = "uri-reference" },
+                ["type"] = typeSchema,
+                ["time"] = new() { Type = SchemaType.String, Format = "date-time" },
+                ["datacontenttype"] = new() { Type = SchemaType.String },
+                ["data"] = dataSchema ?? new AsyncApiJsonSchema(),
+            },
+            Required = new HashSet<string>(StringComparer.Ordinal) { "specversion", "id", "source", "type", "data" },
+        };
     }
 
     private string WireName(MessageTypeMetadata metadata)
@@ -387,6 +485,10 @@ public sealed class AsyncApiDocumentGenerator
 
             if (options == null)
             {
+                _logger?.LogWarning(
+                    "The message body serialization factory ({SerializationFactory}) is not System.Text.Json-based, so the wire contract cannot be derived and messages are documented without payload schemas. " +
+                    "Set AsyncApiOptions.SerializerOptions to options matching the wire format to document payload schemas.",
+                    factory.GetType());
                 return null;
             }
         }
@@ -398,6 +500,9 @@ public sealed class AsyncApiDocumentGenerator
             // to, so messages are documented without payload schemas.
             if (!JsonSerializer.IsReflectionEnabledByDefault)
             {
+                _logger?.LogWarning(
+                    "Reflection-based serialization is disabled and the serializer options have no TypeInfoResolver, so messages are documented without payload schemas. " +
+                    "Use serializer options with a source-generated JsonSerializerContext to document payload schemas.");
                 return null;
             }
 
@@ -413,7 +518,29 @@ public sealed class AsyncApiDocumentGenerator
     }
 
     private string Join(IReadOnlyList<MessageTypeMetadata> messages)
-        => string.Join(", ", messages.Select((m) => m.MessageType.Name));
+        => string.Join(", ", messages.Select((m) => FriendlyTypeName(m.MessageType)));
+
+    /// <summary>
+    /// Renders a type name for display, expanding closed generics (for example
+    /// <c>Envelope&lt;OrderPlaced&gt;</c> rather than <c>Envelope`1</c>). Wire names are never
+    /// derived from this; they stay faithful to the registered logical name.
+    /// </summary>
+    private static string FriendlyTypeName(Type type)
+    {
+        if (!type.IsGenericType)
+        {
+            return type.Name;
+        }
+
+        string name = type.Name;
+        int backtickIndex = name.IndexOf('`');
+        if (backtickIndex > 0)
+        {
+            name = name.Remove(backtickIndex);
+        }
+
+        return $"{name}<{string.Join(", ", type.GenericTypeArguments.Select(FriendlyTypeName))}>";
+    }
 
     private static string Sanitize(string value)
     {

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
@@ -111,7 +111,7 @@ public sealed class AsyncApiDocumentGenerator
 
         var channels = new Dictionary<string, ChannelState>(StringComparer.Ordinal);
         var operationMessages = new Dictionary<string, List<MessageTypeMetadata>>(StringComparer.Ordinal);
-        var envelopeOperations = new HashSet<string>(StringComparer.Ordinal);
+        var envelopedMessages = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
 
         foreach (var publication in _registry.Publications)
         {
@@ -141,7 +141,15 @@ public sealed class AsyncApiDocumentGenerator
 
             if (publication.UsesQueueEnvelope)
             {
-                envelopeOperations.Add(operationKey);
+                if (!envelopedMessages.TryGetValue(operationKey, out var enveloped))
+                {
+                    envelopedMessages[operationKey] = enveloped = new HashSet<string>(StringComparer.Ordinal);
+                }
+
+                foreach (var message in publication.Messages)
+                {
+                    enveloped.Add(WireName(message));
+                }
             }
 
             document.Operations[operationKey] = new AsyncApiOperation()
@@ -149,7 +157,7 @@ public sealed class AsyncApiDocumentGenerator
                 Action = AsyncApiAction.Send,
                 Channel = new AsyncApiChannelReference($"#/channels/{channel.Key}"),
                 Summary = $"Publish {Join(merged)} to {publication.DestinationName}.",
-                Description = envelopeOperations.Contains(operationKey) ? QueueEnvelopeDescription : null,
+                Description = QueueEnvelopeDescription(merged, envelopedMessages.GetValueOrDefault(operationKey)),
                 Messages = [.. merged.Select((m) => new AsyncApiMessageReference($"#/channels/{channel.Key}/messages/{channel.MessageKeys[WireName(m)]}"))],
             };
         }
@@ -382,26 +390,53 @@ public sealed class AsyncApiDocumentGenerator
         return merged;
     }
 
+    private const string QueueEnvelopeShape = "{ \"Message\": \"...\", \"Subject\": \"...\" }";
+
     /// <summary>
     /// Describes how documented payloads are actually written to the queue. Without raw messages,
     /// JustSaying wraps the payload in its own queue envelope, so the SQS body is not the
-    /// documented payload itself.
+    /// documented payload itself. A queue can carry a mix — for example a legacy message alongside
+    /// a self-describing CloudEvent, which is never wrapped — so the envelope is described per
+    /// message rather than for the operation as a whole.
     /// </summary>
-    private const string QueueEnvelopeDescription =
-        "The publisher wraps each message in JustSaying's queue envelope: the SQS message body is " +
-        "{ \"Message\": \"...\", \"Subject\": \"...\" }, and the documented message payload is the JSON-encoded string in its \"Message\" property. " +
-        "Publish with raw messages to send the payload verbatim instead.";
+    private string QueueEnvelopeDescription(IReadOnlyList<MessageTypeMetadata> messages, HashSet<string> envelopedWireNames)
+    {
+        if (envelopedWireNames == null || envelopedWireNames.Count == 0)
+        {
+            return null;
+        }
+
+        var enveloped = messages.Where((m) => envelopedWireNames.Contains(WireName(m))).ToList();
+        var verbatim = messages.Where((m) => !envelopedWireNames.Contains(WireName(m))).ToList();
+
+        string subject = verbatim.Count == 0 ? "The publisher wraps each message" : $"The publisher wraps {Join(enveloped)}";
+        string description =
+            $"{subject} in JustSaying's queue envelope: the SQS message body is {QueueEnvelopeShape}, " +
+            "and the documented message payload is the JSON-encoded string in its \"Message\" property. " +
+            "Publish with raw messages to send the payload verbatim instead.";
+
+        if (verbatim.Count > 0)
+        {
+            description += $" {Join(verbatim)} {(verbatim.Count == 1 ? "is" : "are")} sent verbatim: the SQS message body is the documented message payload.";
+        }
+
+        return description;
+    }
 
     /// <summary>
     /// Describes how documented payloads actually arrive on the queue. Without raw message
     /// delivery, SNS wraps each message in its notification envelope, so the SQS body is not
-    /// the documented payload itself.
+    /// the documented payload itself. A point-to-point subscription that does not use raw message
+    /// delivery accepts either the bare payload or JustSaying's queue envelope, since the producer
+    /// decides which it sends.
     /// </summary>
     private static string DeliveryDescription(SubscriptionMetadata subscription)
     {
         if (subscription.TopicName == null)
         {
-            return null;
+            return subscription.RawMessageDelivery
+                ? "The queue subscription uses raw message delivery: the SQS message body is the documented message payload."
+                : $"The queue subscription accepts the SQS message body either as the documented message payload or wrapped in JustSaying's queue envelope, {QueueEnvelopeShape}, with the documented message payload as the JSON-encoded string in its \"Message\" property.";
         }
 
         return subscription.RawMessageDelivery
@@ -613,7 +648,7 @@ public sealed class AsyncApiDocumentGenerator
             _logger?.LogWarning(
                 "The message body serializer ({Serializer}) is not System.Text.Json-based, so the wire contract cannot be derived and its messages are documented without payload schemas. " +
                 "Set AsyncApiOptions.SerializerOptions to options matching the wire format to document payload schemas.",
-                serializer.GetType());
+                FriendlyTypeName(serializer.GetType()));
         }
 
         return null;

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
@@ -65,7 +65,7 @@ public sealed class AsyncApiDocumentGenerator
 
         AddServers(document, primaryRegion);
 
-        var identities = new Dictionary<string, ChannelIdentity>(StringComparer.Ordinal);
+        var channels = new Dictionary<string, ChannelState>(StringComparer.Ordinal);
         var operationMessages = new Dictionary<string, List<MessageTypeMetadata>>(StringComparer.Ordinal);
 
         foreach (var publication in _registry.Publications)
@@ -76,9 +76,9 @@ public sealed class AsyncApiDocumentGenerator
                 continue;
             }
 
-            var channelKey = AddChannel(
+            var channel = AddChannel(
                 document,
-                identities,
+                channels,
                 primaryRegion,
                 publication.DestinationName,
                 publication.DestinationKind,
@@ -88,15 +88,15 @@ public sealed class AsyncApiDocumentGenerator
 
             // Several publications can target the same destination with different message
             // types; the operation is rebuilt from the merged set so none are dropped.
-            string operationKey = Sanitize($"send-{channelKey}");
+            string operationKey = Sanitize($"send-{channel.Key}");
             var merged = MergeOperationMessages(operationMessages, operationKey, publication.Messages);
 
             document.Operations[operationKey] = new AsyncApiOperation()
             {
                 Action = AsyncApiAction.Send,
-                Channel = new AsyncApiChannelReference($"#/channels/{channelKey}"),
+                Channel = new AsyncApiChannelReference($"#/channels/{channel.Key}"),
                 Summary = $"Publish {Join(merged)} to {publication.DestinationName}.",
-                Messages = [.. merged.Select((m) => new AsyncApiMessageReference($"#/channels/{channelKey}/messages/{MessageKey(m)}"))],
+                Messages = [.. merged.Select((m) => new AsyncApiMessageReference($"#/channels/{channel.Key}/messages/{channel.MessageKeys[WireName(m)]}"))],
             };
         }
 
@@ -106,9 +106,9 @@ public sealed class AsyncApiDocumentGenerator
                 ? $"The {subscription.QueueName} SQS queue, subscribed to the {subscription.TopicName} SNS topic."
                 : $"The {subscription.QueueName} SQS queue.";
 
-            var channelKey = AddChannel(
+            var channel = AddChannel(
                 document,
-                identities,
+                channels,
                 primaryRegion,
                 subscription.QueueName,
                 MessagingDestinationKind.SqsQueue,
@@ -116,15 +116,15 @@ public sealed class AsyncApiDocumentGenerator
                 description,
                 subscription.Messages);
 
-            string operationKey = Sanitize($"receive-{channelKey}");
+            string operationKey = Sanitize($"receive-{channel.Key}");
             var merged = MergeOperationMessages(operationMessages, operationKey, subscription.Messages);
 
             document.Operations[operationKey] = new AsyncApiOperation()
             {
                 Action = AsyncApiAction.Receive,
-                Channel = new AsyncApiChannelReference($"#/channels/{channelKey}"),
+                Channel = new AsyncApiChannelReference($"#/channels/{channel.Key}"),
                 Summary = $"Receive {Join(merged)} from {subscription.QueueName}.",
-                Messages = [.. merged.Select((m) => new AsyncApiMessageReference($"#/channels/{channelKey}/messages/{MessageKey(m)}"))],
+                Messages = [.. merged.Select((m) => new AsyncApiMessageReference($"#/channels/{channel.Key}/messages/{channel.MessageKeys[WireName(m)]}"))],
             };
         }
 
@@ -192,9 +192,24 @@ public sealed class AsyncApiDocumentGenerator
 
     private sealed record ChannelIdentity(string Address, MessagingDestinationKind Kind, string Region);
 
-    private string AddChannel(
+    private sealed class ChannelState(string key, AsyncApiChannel channel, ChannelIdentity identity)
+    {
+        public string Key { get; } = key;
+
+        public AsyncApiChannel Channel { get; } = channel;
+
+        public ChannelIdentity Identity { get; } = identity;
+
+        /// <summary>
+        /// Gets the key each message wire name was allocated within this channel, so that
+        /// operation references point at the message the channel actually holds.
+        /// </summary>
+        public Dictionary<string, string> MessageKeys { get; } = new(StringComparer.Ordinal);
+    }
+
+    private ChannelState AddChannel(
         AsyncApiDocument document,
-        Dictionary<string, ChannelIdentity> identities,
+        Dictionary<string, ChannelState> channels,
         string primaryRegion,
         string address,
         MessagingDestinationKind kind,
@@ -203,24 +218,25 @@ public sealed class AsyncApiDocumentGenerator
         IReadOnlyList<MessageTypeMetadata> messages)
     {
         var identity = new ChannelIdentity(address, kind, region);
+        string kindSuffix = kind == MessagingDestinationKind.SnsTopic ? "topic" : "queue";
 
         // A topic and a queue can share a name, the same name can exist in two regions, and
         // distinct addresses can sanitize to the same key; each is a different destination, so
         // the channel keys are kept distinct. A publication and subscription on the same queue
         // share an identity and reuse the one channel.
-        string channelKey = Sanitize(address);
-        if (identities.TryGetValue(channelKey, out var existing) && existing != identity)
+        List<string> candidates = [Sanitize(address), Sanitize($"{address}-{kindSuffix}")];
+        if (region != null)
         {
-            channelKey = Sanitize($"{address}-{(kind == MessagingDestinationKind.SnsTopic ? "topic" : "queue")}");
-            if (identities.TryGetValue(channelKey, out existing) && existing != identity)
-            {
-                channelKey = Sanitize($"{address}-{(kind == MessagingDestinationKind.SnsTopic ? "topic" : "queue")}-{region}");
-            }
+            candidates.Add(Sanitize($"{address}-{kindSuffix}-{region}"));
         }
 
-        if (!document.Channels.TryGetValue(channelKey, out var channel))
+        string channelKey = AllocateKey(
+            candidates,
+            (key) => !channels.TryGetValue(key, out var existing) || existing.Identity == identity);
+
+        if (!channels.TryGetValue(channelKey, out var state))
         {
-            channel = new AsyncApiChannel()
+            var channel = new AsyncApiChannel()
             {
                 Address = address,
                 Description = description,
@@ -236,15 +252,49 @@ public sealed class AsyncApiDocumentGenerator
             }
 
             document.Channels[channelKey] = channel;
-            identities[channelKey] = identity;
+            channels[channelKey] = state = new ChannelState(channelKey, channel, identity);
         }
 
         foreach (var message in messages)
         {
-            channel.Messages[MessageKey(message)] = CreateMessage(message);
+            string wireName = WireName(message);
+
+            // Distinct wire names can sanitize to the same key, so each is allocated a key of
+            // its own rather than overwriting the message already under that key.
+            if (!state.MessageKeys.TryGetValue(wireName, out var messageKey))
+            {
+                messageKey = AllocateKey([Sanitize(wireName)], (key) => !state.Channel.Messages.ContainsKey(key));
+                state.MessageKeys[wireName] = messageKey;
+            }
+
+            state.Channel.Messages[messageKey] = CreateMessage(message);
         }
 
-        return channelKey;
+        return state;
+    }
+
+    /// <summary>
+    /// Returns the first candidate key that is available, or, when every candidate is taken,
+    /// the last candidate with a deterministic numeric suffix appended until it is available.
+    /// </summary>
+    private static string AllocateKey(IReadOnlyList<string> candidates, Func<string, bool> isAvailable)
+    {
+        foreach (var candidate in candidates)
+        {
+            if (isAvailable(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        for (int i = 2; ; i++)
+        {
+            string candidate = $"{candidates[^1]}-{i}";
+            if (isAvailable(candidate))
+            {
+                return candidate;
+            }
+        }
     }
 
     private List<MessageTypeMetadata> MergeOperationMessages(
@@ -259,7 +309,8 @@ public sealed class AsyncApiDocumentGenerator
 
         foreach (var message in messages)
         {
-            if (!merged.Any((m) => MessageKey(m) == MessageKey(message)))
+            string wireName = WireName(message);
+            if (!merged.Any((m) => WireName(m) == wireName))
             {
                 merged.Add(message);
             }
@@ -360,8 +411,6 @@ public sealed class AsyncApiDocumentGenerator
 
         return options;
     }
-
-    private string MessageKey(MessageTypeMetadata metadata) => Sanitize(WireName(metadata));
 
     private string Join(IReadOnlyList<MessageTypeMetadata> messages)
         => string.Join(", ", messages.Select((m) => m.MessageType.Name));

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
@@ -1,0 +1,291 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Schema;
+using ByteBard.AsyncAPI.Models;
+using JustSaying.CloudEvents;
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Metadata;
+
+namespace JustSaying.AsyncApi;
+
+/// <summary>
+/// Generates an AsyncAPI 3.0 document from the publications and subscriptions captured in an
+/// <see cref="IMessagingMetadataRegistry"/>.
+/// </summary>
+public sealed class AsyncApiDocumentGenerator
+{
+    private const string CloudEventsContentType = "application/cloudevents+json";
+
+    private readonly IMessagingMetadataRegistry _registry;
+    private readonly AsyncApiOptions _options;
+    private readonly IMessageBodySerializationFactory _serializationFactory;
+    private readonly CloudEventOptions _cloudEventOptions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncApiDocumentGenerator"/> class.
+    /// </summary>
+    /// <param name="registry">The registry of captured publications and subscriptions.</param>
+    /// <param name="options">The options configuring the generated document.</param>
+    /// <param name="serializationFactory">The message body serialization factory in use, used to discover the payload wire contract.</param>
+    /// <param name="cloudEventOptions">The CloudEvents options, when CloudEvents support is configured.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="registry"/> or <paramref name="options"/> is <see langword="null"/>.
+    /// </exception>
+    public AsyncApiDocumentGenerator(
+        IMessagingMetadataRegistry registry,
+        AsyncApiOptions options,
+        IMessageBodySerializationFactory serializationFactory = null,
+        CloudEventOptions cloudEventOptions = null)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _serializationFactory = serializationFactory;
+        _cloudEventOptions = cloudEventOptions;
+    }
+
+    /// <summary>
+    /// Generates the AsyncAPI document.
+    /// </summary>
+    /// <returns>The generated <see cref="AsyncApiDocument"/>.</returns>
+    public AsyncApiDocument Generate()
+    {
+        var document = new AsyncApiDocument()
+        {
+            Id = _options.Id,
+            Info = new AsyncApiInfo()
+            {
+                Title = _options.Title ?? Assembly.GetEntryAssembly()?.GetName().Name ?? "JustSaying application",
+                Version = _options.Version,
+                Description = _options.Description,
+            },
+            DefaultContentType = _cloudEventOptions != null ? CloudEventsContentType : "application/json",
+        };
+
+        AddServers(document);
+
+        foreach (var publication in _registry.Publications)
+        {
+            if (publication.IsDynamic)
+            {
+                // A dynamic destination has no static address; there is no channel to document.
+                continue;
+            }
+
+            var channelKey = AddChannel(
+                document,
+                publication.DestinationName,
+                publication.DestinationKind,
+                $"The {publication.DestinationName} {(publication.DestinationKind == MessagingDestinationKind.SnsTopic ? "SNS topic" : "SQS queue")}.",
+                publication.Messages);
+
+            document.Operations[Sanitize($"send-{channelKey}")] = new AsyncApiOperation()
+            {
+                Action = AsyncApiAction.Send,
+                Channel = new AsyncApiChannelReference($"#/channels/{channelKey}"),
+                Summary = $"Publish {Join(publication.Messages)} to {publication.DestinationName}.",
+                Messages = [.. publication.Messages.Select((m) => new AsyncApiMessageReference($"#/channels/{channelKey}/messages/{MessageKey(m)}"))],
+            };
+        }
+
+        foreach (var subscription in _registry.Subscriptions)
+        {
+            var description = subscription.TopicName != null
+                ? $"The {subscription.QueueName} SQS queue, subscribed to the {subscription.TopicName} SNS topic."
+                : $"The {subscription.QueueName} SQS queue.";
+
+            var channelKey = AddChannel(
+                document,
+                subscription.QueueName,
+                MessagingDestinationKind.SqsQueue,
+                description,
+                subscription.Messages);
+
+            document.Operations[Sanitize($"receive-{channelKey}")] = new AsyncApiOperation()
+            {
+                Action = AsyncApiAction.Receive,
+                Channel = new AsyncApiChannelReference($"#/channels/{channelKey}"),
+                Summary = $"Receive {Join(subscription.Messages)} from {subscription.QueueName}.",
+                Messages = [.. subscription.Messages.Select((m) => new AsyncApiMessageReference($"#/channels/{channelKey}/messages/{MessageKey(m)}"))],
+            };
+        }
+
+        _options.PostProcess?.Invoke(document);
+
+        return document;
+    }
+
+    private void AddServers(AsyncApiDocument document)
+    {
+        var region = _registry.Region;
+        if (region == null)
+        {
+            return;
+        }
+
+        bool anyTopics = _registry.Publications.Any((p) => p.DestinationKind == MessagingDestinationKind.SnsTopic)
+            || _registry.Subscriptions.Any((s) => s.TopicName != null);
+        bool anyQueues = _registry.Publications.Any((p) => p.DestinationKind == MessagingDestinationKind.SqsQueue)
+            || _registry.Subscriptions.Count > 0;
+
+        if (anyTopics)
+        {
+            document.Servers["sns"] = new AsyncApiServer()
+            {
+                Host = $"sns.{region}.amazonaws.com",
+                Protocol = "sns",
+                Description = $"Amazon SNS in {region}.",
+            };
+        }
+
+        if (anyQueues)
+        {
+            document.Servers["sqs"] = new AsyncApiServer()
+            {
+                Host = $"sqs.{region}.amazonaws.com",
+                Protocol = "sqs",
+                Description = $"Amazon SQS in {region}.",
+            };
+        }
+    }
+
+    private string AddChannel(
+        AsyncApiDocument document,
+        string address,
+        MessagingDestinationKind kind,
+        string description,
+        IReadOnlyList<MessageTypeMetadata> messages)
+    {
+        string channelKey = Sanitize(address);
+        if (document.Channels.TryGetValue(channelKey, out var existing) && existing.Address != address)
+        {
+            // A topic and a queue can share a name; keep the channel keys distinct.
+            channelKey = Sanitize($"{address}-{(kind == MessagingDestinationKind.SnsTopic ? "topic" : "queue")}");
+        }
+
+        if (!document.Channels.TryGetValue(channelKey, out var channel))
+        {
+            channel = new AsyncApiChannel()
+            {
+                Address = address,
+                Description = description,
+            };
+
+            string serverKey = kind == MessagingDestinationKind.SnsTopic ? "sns" : "sqs";
+            if (document.Servers.ContainsKey(serverKey))
+            {
+                channel.Servers.Add(new AsyncApiServerReference($"#/servers/{serverKey}"));
+            }
+
+            document.Channels[channelKey] = channel;
+        }
+
+        foreach (var message in messages)
+        {
+            channel.Messages[MessageKey(message)] = CreateMessage(message);
+        }
+
+        return channelKey;
+    }
+
+    private AsyncApiMessage CreateMessage(MessageTypeMetadata metadata)
+    {
+        string name = WireName(metadata);
+
+        var message = new AsyncApiMessage()
+        {
+            Name = name,
+            Title = metadata.MessageType.Name,
+            ContentType = _cloudEventOptions != null ? CloudEventsContentType : "application/json",
+        };
+
+        var serializerOptions = ResolveSerializerOptions();
+        if (serializerOptions != null)
+        {
+            try
+            {
+                var schemaNode = serializerOptions.GetJsonSchemaAsNode(metadata.MessageType, new JsonSchemaExporterOptions
+                {
+                    TreatNullObliviousAsNonNullable = true,
+                });
+
+                message.Payload = JsonSchemaNodeMapper.Map(schemaNode);
+            }
+            catch (NotSupportedException)
+            {
+                // The serializer cannot describe this type; the message is documented without a payload schema.
+            }
+        }
+
+        return message;
+    }
+
+    private string WireName(MessageTypeMetadata metadata)
+    {
+        if (_cloudEventOptions != null && _cloudEventOptions.TryGetCloudEventType(metadata.MessageType, out var cloudEventType))
+        {
+            return cloudEventType;
+        }
+
+        return metadata.WireName ?? metadata.MessageType.Name;
+    }
+
+    private JsonSerializerOptions ResolveSerializerOptions()
+    {
+        var options = _options.SerializerOptions;
+
+        if (options == null)
+        {
+            var factory = _serializationFactory;
+            if (factory is CloudEventSerializationFactory cloudEventFactory)
+            {
+                factory = cloudEventFactory.DataSerializerFactory;
+            }
+
+            options = factory is SystemTextJsonSerializationFactory systemTextJsonFactory
+                ? systemTextJsonFactory.SerializerOptions
+                : SystemTextJsonMessageBodySerializer.DefaultJsonSerializerOptions;
+        }
+
+        if (options.TypeInfoResolver == null)
+        {
+            // The schema exporter requires a resolver to be set explicitly; the serializers rely on
+            // it being applied lazily. Under Native AOT there is no reflection resolver to fall back
+            // to, so messages are documented without payload schemas.
+            if (!JsonSerializer.IsReflectionEnabledByDefault)
+            {
+                return null;
+            }
+
+#pragma warning disable IL2026, IL3050
+            options = new JsonSerializerOptions(options)
+            {
+                TypeInfoResolver = JsonSerializerOptions.Default.TypeInfoResolver,
+            };
+#pragma warning restore IL2026, IL3050
+        }
+
+        return options;
+    }
+
+    private string MessageKey(MessageTypeMetadata metadata) => Sanitize(WireName(metadata));
+
+    private string Join(IReadOnlyList<MessageTypeMetadata> messages)
+        => string.Join(", ", messages.Select((m) => m.MessageType.Name));
+
+    private static string Sanitize(string value)
+    {
+        // AsyncAPI object keys must match ^[A-Za-z0-9._-]+$.
+        char[] result = value.ToCharArray();
+        for (int i = 0; i < result.Length; i++)
+        {
+            char c = result[i];
+            bool valid = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-';
+            if (!valid)
+            {
+                result[i] = '_';
+            }
+        }
+
+        return new string(result);
+    }
+}

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
@@ -61,7 +61,12 @@ public sealed class AsyncApiDocumentGenerator
             DefaultContentType = _cloudEventOptions != null ? CloudEventsContentType : "application/json",
         };
 
-        AddServers(document);
+        string primaryRegion = PrimaryRegion();
+
+        AddServers(document, primaryRegion);
+
+        var identities = new Dictionary<string, ChannelIdentity>(StringComparer.Ordinal);
+        var operationMessages = new Dictionary<string, List<MessageTypeMetadata>>(StringComparer.Ordinal);
 
         foreach (var publication in _registry.Publications)
         {
@@ -73,17 +78,25 @@ public sealed class AsyncApiDocumentGenerator
 
             var channelKey = AddChannel(
                 document,
+                identities,
+                primaryRegion,
                 publication.DestinationName,
                 publication.DestinationKind,
+                publication.Region ?? _registry.Region,
                 $"The {publication.DestinationName} {(publication.DestinationKind == MessagingDestinationKind.SnsTopic ? "SNS topic" : "SQS queue")}.",
                 publication.Messages);
 
-            document.Operations[Sanitize($"send-{channelKey}")] = new AsyncApiOperation()
+            // Several publications can target the same destination with different message
+            // types; the operation is rebuilt from the merged set so none are dropped.
+            string operationKey = Sanitize($"send-{channelKey}");
+            var merged = MergeOperationMessages(operationMessages, operationKey, publication.Messages);
+
+            document.Operations[operationKey] = new AsyncApiOperation()
             {
                 Action = AsyncApiAction.Send,
                 Channel = new AsyncApiChannelReference($"#/channels/{channelKey}"),
-                Summary = $"Publish {Join(publication.Messages)} to {publication.DestinationName}.",
-                Messages = [.. publication.Messages.Select((m) => new AsyncApiMessageReference($"#/channels/{channelKey}/messages/{MessageKey(m)}"))],
+                Summary = $"Publish {Join(merged)} to {publication.DestinationName}.",
+                Messages = [.. merged.Select((m) => new AsyncApiMessageReference($"#/channels/{channelKey}/messages/{MessageKey(m)}"))],
             };
         }
 
@@ -95,17 +108,23 @@ public sealed class AsyncApiDocumentGenerator
 
             var channelKey = AddChannel(
                 document,
+                identities,
+                primaryRegion,
                 subscription.QueueName,
                 MessagingDestinationKind.SqsQueue,
+                subscription.Region ?? _registry.Region,
                 description,
                 subscription.Messages);
 
-            document.Operations[Sanitize($"receive-{channelKey}")] = new AsyncApiOperation()
+            string operationKey = Sanitize($"receive-{channelKey}");
+            var merged = MergeOperationMessages(operationMessages, operationKey, subscription.Messages);
+
+            document.Operations[operationKey] = new AsyncApiOperation()
             {
                 Action = AsyncApiAction.Receive,
                 Channel = new AsyncApiChannelReference($"#/channels/{channelKey}"),
-                Summary = $"Receive {Join(subscription.Messages)} from {subscription.QueueName}.",
-                Messages = [.. subscription.Messages.Select((m) => new AsyncApiMessageReference($"#/channels/{channelKey}/messages/{MessageKey(m)}"))],
+                Summary = $"Receive {Join(merged)} from {subscription.QueueName}.",
+                Messages = [.. merged.Select((m) => new AsyncApiMessageReference($"#/channels/{channelKey}/messages/{MessageKey(m)}"))],
             };
         }
 
@@ -114,22 +133,42 @@ public sealed class AsyncApiDocumentGenerator
         return document;
     }
 
-    private void AddServers(AsyncApiDocument document)
+    /// <summary>
+    /// The region whose servers get the plain "sns"/"sqs" keys; destinations in any other
+    /// region reference a region-suffixed server. This is the bus's configured region, or,
+    /// when only explicitly-addressed destinations exist, their sole region.
+    /// </summary>
+    private string PrimaryRegion()
     {
-        var region = _registry.Region;
-        if (region == null)
+        if (_registry.Region != null)
         {
-            return;
+            return _registry.Region;
         }
 
-        bool anyTopics = _registry.Publications.Any((p) => p.DestinationKind == MessagingDestinationKind.SnsTopic)
-            || _registry.Subscriptions.Any((s) => s.TopicName != null);
-        bool anyQueues = _registry.Publications.Any((p) => p.DestinationKind == MessagingDestinationKind.SqsQueue)
-            || _registry.Subscriptions.Count > 0;
+        var regions = _registry.Publications.Select((p) => p.Region)
+            .Concat(_registry.Subscriptions.Select((s) => s.Region))
+            .Where((r) => r != null)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
 
-        if (anyTopics)
+        return regions.Count == 1 ? regions[0] : null;
+    }
+
+    private void AddServers(AsyncApiDocument document, string primaryRegion)
+    {
+        var topicRegions = _registry.Publications
+            .Where((p) => p.DestinationKind == MessagingDestinationKind.SnsTopic)
+            .Select((p) => p.Region ?? _registry.Region)
+            .Concat(_registry.Subscriptions.Where((s) => s.TopicName != null).Select((s) => s.Region ?? _registry.Region));
+
+        var queueRegions = _registry.Publications
+            .Where((p) => p.DestinationKind == MessagingDestinationKind.SqsQueue)
+            .Select((p) => p.Region ?? _registry.Region)
+            .Concat(_registry.Subscriptions.Select((s) => s.Region ?? _registry.Region));
+
+        foreach (var region in topicRegions.Where((r) => r != null).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal))
         {
-            document.Servers["sns"] = new AsyncApiServer()
+            document.Servers[ServerKey("sns", region, primaryRegion)] = new AsyncApiServer()
             {
                 Host = $"sns.{region}.amazonaws.com",
                 Protocol = "sns",
@@ -137,9 +176,9 @@ public sealed class AsyncApiDocumentGenerator
             };
         }
 
-        if (anyQueues)
+        foreach (var region in queueRegions.Where((r) => r != null).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal))
         {
-            document.Servers["sqs"] = new AsyncApiServer()
+            document.Servers[ServerKey("sqs", region, primaryRegion)] = new AsyncApiServer()
             {
                 Host = $"sqs.{region}.amazonaws.com",
                 Protocol = "sqs",
@@ -148,18 +187,35 @@ public sealed class AsyncApiDocumentGenerator
         }
     }
 
+    private static string ServerKey(string protocol, string region, string primaryRegion)
+        => region == primaryRegion ? protocol : Sanitize($"{protocol}-{region}");
+
+    private sealed record ChannelIdentity(string Address, MessagingDestinationKind Kind, string Region);
+
     private string AddChannel(
         AsyncApiDocument document,
+        Dictionary<string, ChannelIdentity> identities,
+        string primaryRegion,
         string address,
         MessagingDestinationKind kind,
+        string region,
         string description,
         IReadOnlyList<MessageTypeMetadata> messages)
     {
+        var identity = new ChannelIdentity(address, kind, region);
+
+        // A topic and a queue can share a name, the same name can exist in two regions, and
+        // distinct addresses can sanitize to the same key; each is a different destination, so
+        // the channel keys are kept distinct. A publication and subscription on the same queue
+        // share an identity and reuse the one channel.
         string channelKey = Sanitize(address);
-        if (document.Channels.TryGetValue(channelKey, out var existing) && existing.Address != address)
+        if (identities.TryGetValue(channelKey, out var existing) && existing != identity)
         {
-            // A topic and a queue can share a name; keep the channel keys distinct.
             channelKey = Sanitize($"{address}-{(kind == MessagingDestinationKind.SnsTopic ? "topic" : "queue")}");
+            if (identities.TryGetValue(channelKey, out existing) && existing != identity)
+            {
+                channelKey = Sanitize($"{address}-{(kind == MessagingDestinationKind.SnsTopic ? "topic" : "queue")}-{region}");
+            }
         }
 
         if (!document.Channels.TryGetValue(channelKey, out var channel))
@@ -170,13 +226,17 @@ public sealed class AsyncApiDocumentGenerator
                 Description = description,
             };
 
-            string serverKey = kind == MessagingDestinationKind.SnsTopic ? "sns" : "sqs";
-            if (document.Servers.ContainsKey(serverKey))
+            if (region != null)
             {
-                channel.Servers.Add(new AsyncApiServerReference($"#/servers/{serverKey}"));
+                string serverKey = ServerKey(kind == MessagingDestinationKind.SnsTopic ? "sns" : "sqs", region, primaryRegion);
+                if (document.Servers.ContainsKey(serverKey))
+                {
+                    channel.Servers.Add(new AsyncApiServerReference($"#/servers/{serverKey}"));
+                }
             }
 
             document.Channels[channelKey] = channel;
+            identities[channelKey] = identity;
         }
 
         foreach (var message in messages)
@@ -185,6 +245,27 @@ public sealed class AsyncApiDocumentGenerator
         }
 
         return channelKey;
+    }
+
+    private List<MessageTypeMetadata> MergeOperationMessages(
+        Dictionary<string, List<MessageTypeMetadata>> operationMessages,
+        string operationKey,
+        IReadOnlyList<MessageTypeMetadata> messages)
+    {
+        if (!operationMessages.TryGetValue(operationKey, out var merged))
+        {
+            operationMessages[operationKey] = merged = [];
+        }
+
+        foreach (var message in messages)
+        {
+            if (!merged.Any((m) => MessageKey(m) == MessageKey(message)))
+            {
+                merged.Add(message);
+            }
+        }
+
+        return merged;
     }
 
     private AsyncApiMessage CreateMessage(MessageTypeMetadata metadata)
@@ -241,9 +322,22 @@ public sealed class AsyncApiDocumentGenerator
                 factory = cloudEventFactory.DataSerializerFactory;
             }
 
-            options = factory is SystemTextJsonSerializationFactory systemTextJsonFactory
-                ? systemTextJsonFactory.SerializerOptions
-                : SystemTextJsonMessageBodySerializer.DefaultJsonSerializerOptions;
+            options = factory switch
+            {
+                SystemTextJsonSerializationFactory systemTextJsonFactory => systemTextJsonFactory.SerializerOptions,
+                null => SystemTextJsonMessageBodySerializer.DefaultJsonSerializerOptions,
+                // A Newtonsoft or custom factory's wire contract cannot be derived from
+                // System.Text.Json options (for example, JustSaying's Newtonsoft serializer
+                // writes enums as strings), so rather than documenting a schema that may not
+                // match the wire format, messages are documented without payload schemas
+                // unless AsyncApiOptions.SerializerOptions is supplied explicitly.
+                _ => null,
+            };
+
+            if (options == null)
+            {
+                return null;
+            }
         }
 
         if (options.TypeInfoResolver == null)

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentGenerator.cs
@@ -91,6 +91,7 @@ public sealed class AsyncApiDocumentGenerator
         var serializerOptions = ResolveSerializerOptions();
         var channels = new Dictionary<string, ChannelState>(StringComparer.Ordinal);
         var operationMessages = new Dictionary<string, List<MessageTypeMetadata>>(StringComparer.Ordinal);
+        var envelopeOperations = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var publication in _registry.Publications)
         {
@@ -119,11 +120,17 @@ public sealed class AsyncApiDocumentGenerator
             string operationKey = Sanitize($"send-{channel.Key}");
             var merged = MergeOperationMessages(operationMessages, operationKey, publication.Messages);
 
+            if (publication.UsesQueueEnvelope)
+            {
+                envelopeOperations.Add(operationKey);
+            }
+
             document.Operations[operationKey] = new AsyncApiOperation()
             {
                 Action = AsyncApiAction.Send,
                 Channel = new AsyncApiChannelReference($"#/channels/{channel.Key}"),
                 Summary = $"Publish {Join(merged)} to {publication.DestinationName}.",
+                Description = envelopeOperations.Contains(operationKey) ? QueueEnvelopeDescription : null,
                 Messages = [.. merged.Select((m) => new AsyncApiMessageReference($"#/channels/{channel.Key}/messages/{channel.MessageKeys[WireName(m)]}"))],
             };
         }
@@ -349,6 +356,16 @@ public sealed class AsyncApiDocumentGenerator
 
         return merged;
     }
+
+    /// <summary>
+    /// Describes how documented payloads are actually written to the queue. Without raw messages,
+    /// JustSaying wraps the payload in its own queue envelope, so the SQS body is not the
+    /// documented payload itself.
+    /// </summary>
+    private const string QueueEnvelopeDescription =
+        "The publisher wraps each message in JustSaying's queue envelope: the SQS message body is " +
+        "{ \"Message\": \"...\", \"Subject\": \"...\" }, and the documented message payload is the JSON-encoded string in its \"Message\" property. " +
+        "Publish with raw messages to send the payload verbatim instead.";
 
     /// <summary>
     /// Describes how documented payloads actually arrive on the queue. Without raw message

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentProvider.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentProvider.cs
@@ -32,6 +32,6 @@ internal sealed class AsyncApiDocumentProvider(IServiceProvider serviceProvider)
         var generator = serviceProvider.GetRequiredService<AsyncApiDocumentGenerator>();
         var document = generator.Generate();
 
-        await writer.WriteAsync(document.SerializeAsJson(AsyncApiVersion.AsyncApi3_0)).ConfigureAwait(false);
+        await writer.WriteAsync(document.SerializeAsJson(AsyncApiVersion.AsyncApi3_0).AsMemory(), cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentProvider.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentProvider.cs
@@ -33,17 +33,40 @@ internal sealed class AsyncApiDocumentProvider(IServiceProvider serviceProvider)
         }
         catch (Exception exception) when (exception is InvalidOperationException or HandlerNotRegisteredWithContainerException or NotSupportedException)
         {
-            throw new InvalidOperationException(
-                "Generating an AsyncAPI document builds the JustSaying messaging bus (without starting it), and building the bus failed. " +
-                "A common cause in documentation-only entry points is a subscription whose message handler is not registered; " +
-                "handlers must be registered (for example with AddJustSayingHandler) even when only generating a document. " +
-                $"The underlying error was: {exception.Message}",
-                exception);
+            // Lead with the actual error; the bus-build context and the handler hint come after, and the
+            // hint only when a missing handler is what failed, so a CloudEvents or naming misconfiguration
+            // is not mislabelled as a handler problem.
+            string message =
+                $"{exception.Message} " +
+                "(Generating an AsyncAPI document builds the JustSaying messaging bus, without starting it, and building the bus failed.";
+
+            if (IsMissingHandler(exception))
+            {
+                message +=
+                    " Handlers must be registered, for example with AddJustSayingHandler, even in a documentation-only entry point, " +
+                    "because the bus resolves each subscription's handler when it is built.";
+            }
+
+            throw new InvalidOperationException(message + ")", exception);
         }
 
         var generator = serviceProvider.GetRequiredService<AsyncApiDocumentGenerator>();
         var document = generator.Generate();
 
         await writer.WriteAsync(document.SerializeAsJson(AsyncApiVersion.AsyncApi3_0).AsMemory(), cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool IsMissingHandler(Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current is HandlerNotRegisteredWithContainerException ||
+                current.Message.Contains("No handler for message type", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentProvider.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentProvider.cs
@@ -26,8 +26,20 @@ internal sealed class AsyncApiDocumentProvider(IServiceProvider serviceProvider)
 
         // Building the publisher and the subscribers runs the fluent builders' configuration,
         // which populates the metadata registry. Neither starts the bus.
-        _ = serviceProvider.GetService<IMessagePublisher>();
-        _ = serviceProvider.GetService<IMessagingBus>();
+        try
+        {
+            _ = serviceProvider.GetService<IMessagePublisher>();
+            _ = serviceProvider.GetService<IMessagingBus>();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or HandlerNotRegisteredWithContainerException or NotSupportedException)
+        {
+            throw new InvalidOperationException(
+                "Generating an AsyncAPI document builds the JustSaying messaging bus (without starting it), and building the bus failed. " +
+                "A common cause in documentation-only entry points is a subscription whose message handler is not registered; " +
+                "handlers must be registered (for example with AddJustSayingHandler) even when only generating a document. " +
+                $"The underlying error was: {exception.Message}",
+                exception);
+        }
 
         var generator = serviceProvider.GetRequiredService<AsyncApiDocumentGenerator>();
         var document = generator.Generate();

--- a/src/JustSaying.AsyncApi/AsyncApiDocumentProvider.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiDocumentProvider.cs
@@ -1,0 +1,37 @@
+using ByteBard.AsyncAPI;
+using ByteBard.AsyncAPI.Models;
+using JustSaying.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.AsyncApi;
+
+/// <summary>
+/// The default <see cref="IAsyncApiDocumentProvider"/>. Forces the messaging bus to be built
+/// (which populates the metadata registry without starting the bus or provisioning any AWS
+/// infrastructure) and serializes the generated document.
+/// </summary>
+internal sealed class AsyncApiDocumentProvider(IServiceProvider serviceProvider) : IAsyncApiDocumentProvider
+{
+    internal const string DefaultDocumentName = "asyncapi";
+
+    public IReadOnlyList<string> GetDocumentNames() => [DefaultDocumentName];
+
+    public async Task GenerateAsync(string documentName, TextWriter writer, CancellationToken cancellationToken = default)
+    {
+        if (writer == null) throw new ArgumentNullException(nameof(writer));
+        if (documentName != DefaultDocumentName)
+        {
+            throw new ArgumentException($"Unknown AsyncAPI document '{documentName}'.", nameof(documentName));
+        }
+
+        // Building the publisher and the subscribers runs the fluent builders' configuration,
+        // which populates the metadata registry. Neither starts the bus.
+        _ = serviceProvider.GetService<IMessagePublisher>();
+        _ = serviceProvider.GetService<IMessagingBus>();
+
+        var generator = serviceProvider.GetRequiredService<AsyncApiDocumentGenerator>();
+        var document = generator.Generate();
+
+        await writer.WriteAsync(document.SerializeAsJson(AsyncApiVersion.AsyncApi3_0)).ConfigureAwait(false);
+    }
+}

--- a/src/JustSaying.AsyncApi/AsyncApiOptions.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiOptions.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using ByteBard.AsyncAPI.Models;
+
+namespace JustSaying.AsyncApi;
+
+/// <summary>
+/// Configures the AsyncAPI document generated for the messaging bus.
+/// </summary>
+public sealed class AsyncApiOptions
+{
+    /// <summary>
+    /// Gets or sets the identifier of the application, used for the document's <c>id</c> field.
+    /// </summary>
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the title of the application. Defaults to the entry assembly name.
+    /// </summary>
+    public string Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version of the application API. Defaults to <c>1.0.0</c>.
+    /// </summary>
+    public string Version { get; set; } = "1.0.0";
+
+    /// <summary>
+    /// Gets or sets a description of the application.
+    /// </summary>
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="JsonSerializerOptions"/> used to generate message payload
+    /// schemas. When <see langword="null"/>, the options are discovered from the configured
+    /// message body serialization factory, falling back to the serializer defaults.
+    /// </summary>
+    public JsonSerializerOptions SerializerOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a delegate invoked with the generated document before it is serialized,
+    /// allowing arbitrary customization.
+    /// </summary>
+    public Action<AsyncApiDocument> PostProcess { get; set; }
+}

--- a/src/JustSaying.AsyncApi/AsyncApiServiceCollectionExtensions.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+using JustSaying.AsyncApi;
+using JustSaying.Messaging.Metadata;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for configuring AsyncAPI document generation on an <see cref="IServiceCollection"/>.
+/// </summary>
+public static class AsyncApiServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds AsyncAPI document generation for the JustSaying messaging bus. Registers an
+    /// <see cref="IMessagingMetadataRegistry"/>, which the fluent builders populate with
+    /// publication and subscription metadata as the bus is configured, and an
+    /// <see cref="IAsyncApiDocumentProvider"/> that generates AsyncAPI 3.0 documents from it.
+    /// </summary>
+    /// <param name="services">The service collection to add AsyncAPI support to.</param>
+    /// <param name="configure">An optional delegate used to configure the <see cref="AsyncApiOptions"/>.</param>
+    /// <returns>The same <see cref="IServiceCollection"/>, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="services"/> is <see langword="null"/>.
+    /// </exception>
+    public static IServiceCollection AddJustSayingAsyncApi(
+        this IServiceCollection services,
+        Action<AsyncApiOptions> configure = null)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
+
+        var options = new AsyncApiOptions();
+        configure?.Invoke(options);
+
+        services.TryAddSingleton(options);
+        services.TryAddSingleton<IMessagingMetadataRegistry, MessagingMetadataRegistry>();
+        services.TryAddSingleton((serviceProvider) => new AsyncApiDocumentGenerator(
+            serviceProvider.GetRequiredService<IMessagingMetadataRegistry>(),
+            serviceProvider.GetRequiredService<AsyncApiOptions>(),
+            serviceProvider.GetService<JustSaying.Messaging.MessageSerialization.IMessageBodySerializationFactory>(),
+            serviceProvider.GetService<JustSaying.CloudEvents.CloudEventOptions>()));
+        services.TryAddSingleton<IAsyncApiDocumentProvider, AsyncApiDocumentProvider>();
+
+        return services;
+    }
+}

--- a/src/JustSaying.AsyncApi/AsyncApiServiceCollectionExtensions.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ public static class AsyncApiServiceCollectionExtensions
     /// Adds AsyncAPI document generation for the JustSaying messaging bus. Registers an
     /// <see cref="IMessagingMetadataRegistry"/>, which the fluent builders populate with
     /// publication and subscription metadata as the bus is configured, and an
-    /// <see cref="IAsyncApiDocumentProvider"/> that generates AsyncAPI 3.0 documents from it.
+    /// <see cref="IAsyncApiDocumentProvider"/> that generates AsyncAPI 3.1 documents from it.
     /// </summary>
     /// <param name="services">The service collection to add AsyncAPI support to.</param>
     /// <param name="configure">An optional delegate used to configure the <see cref="AsyncApiOptions"/>.</param>
@@ -36,7 +36,8 @@ public static class AsyncApiServiceCollectionExtensions
             serviceProvider.GetRequiredService<IMessagingMetadataRegistry>(),
             serviceProvider.GetRequiredService<AsyncApiOptions>(),
             serviceProvider.GetService<JustSaying.Messaging.MessageSerialization.IMessageBodySerializationFactory>(),
-            serviceProvider.GetService<JustSaying.CloudEvents.CloudEventOptions>()));
+            serviceProvider.GetService<JustSaying.CloudEvents.CloudEventOptions>(),
+            serviceProvider.GetService<Microsoft.Extensions.Logging.ILogger<AsyncApiDocumentGenerator>>()));
         services.TryAddSingleton<IAsyncApiDocumentProvider, AsyncApiDocumentProvider>();
 
         return services;

--- a/src/JustSaying.AsyncApi/AsyncApiServiceCollectionExtensions.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ public static class AsyncApiServiceCollectionExtensions
     /// Adds AsyncAPI document generation for the JustSaying messaging bus. Registers an
     /// <see cref="IMessagingMetadataRegistry"/>, which the fluent builders populate with
     /// publication and subscription metadata as the bus is configured, and an
-    /// <see cref="IAsyncApiDocumentProvider"/> that generates AsyncAPI 3.1 documents from it.
+    /// <see cref="IAsyncApiDocumentProvider"/> that generates AsyncAPI 3.0 documents from it.
     /// </summary>
     /// <param name="services">The service collection to add AsyncAPI support to.</param>
     /// <param name="configure">An optional delegate used to configure the <see cref="AsyncApiOptions"/>.</param>

--- a/src/JustSaying.AsyncApi/AsyncApiServiceCollectionExtensions.cs
+++ b/src/JustSaying.AsyncApi/AsyncApiServiceCollectionExtensions.cs
@@ -36,7 +36,6 @@ public static class AsyncApiServiceCollectionExtensions
             serviceProvider.GetRequiredService<IMessagingMetadataRegistry>(),
             serviceProvider.GetRequiredService<AsyncApiOptions>(),
             serviceProvider.GetService<JustSaying.Messaging.MessageSerialization.IMessageBodySerializationFactory>(),
-            serviceProvider.GetService<JustSaying.CloudEvents.CloudEventOptions>(),
             serviceProvider.GetService<Microsoft.Extensions.Logging.ILogger<AsyncApiDocumentGenerator>>()));
         services.TryAddSingleton<IAsyncApiDocumentProvider, AsyncApiDocumentProvider>();
 

--- a/src/JustSaying.AsyncApi/IAsyncApiDocumentProvider.cs
+++ b/src/JustSaying.AsyncApi/IAsyncApiDocumentProvider.cs
@@ -1,0 +1,27 @@
+namespace JustSaying.AsyncApi;
+
+/// <summary>
+/// Provides serialized AsyncAPI documents for the application.
+/// </summary>
+/// <remarks>
+/// This interface is resolved by name by external tooling (analogous to how ASP.NET Core's
+/// build-time OpenAPI generation resolves <c>Microsoft.Extensions.ApiDescriptions.IDocumentProvider</c>),
+/// so its full name and member signatures must remain stable.
+/// </remarks>
+public interface IAsyncApiDocumentProvider
+{
+    /// <summary>
+    /// Gets the names of the documents that can be generated.
+    /// </summary>
+    /// <returns>The available document names.</returns>
+    IReadOnlyList<string> GetDocumentNames();
+
+    /// <summary>
+    /// Generates the specified document as AsyncAPI 3.0 JSON and writes it to the writer.
+    /// </summary>
+    /// <param name="documentName">The name of the document to generate.</param>
+    /// <param name="writer">The writer to write the document to.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when the document has been written.</returns>
+    Task GenerateAsync(string documentName, TextWriter writer, CancellationToken cancellationToken = default);
+}

--- a/src/JustSaying.AsyncApi/IAsyncApiDocumentProvider.cs
+++ b/src/JustSaying.AsyncApi/IAsyncApiDocumentProvider.cs
@@ -17,11 +17,18 @@ public interface IAsyncApiDocumentProvider
     IReadOnlyList<string> GetDocumentNames();
 
     /// <summary>
-    /// Generates the specified document as AsyncAPI 3.0 JSON and writes it to the writer.
+    /// Generates the specified document as AsyncAPI JSON and writes it to the writer.
     /// </summary>
     /// <param name="documentName">The name of the document to generate.</param>
     /// <param name="writer">The writer to write the document to.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A task that completes when the document has been written.</returns>
+    /// <remarks>
+    /// Generation builds the JustSaying messaging bus (without starting it or making any AWS
+    /// calls) to collect the configured publications and subscriptions. The application's
+    /// dependency injection registrations must therefore be complete — in particular, every
+    /// subscription's message handler must be registered, even in entry points that only
+    /// generate a document.
+    /// </remarks>
     Task GenerateAsync(string documentName, TextWriter writer, CancellationToken cancellationToken = default);
 }

--- a/src/JustSaying.AsyncApi/JsonSchemaNodeMapper.cs
+++ b/src/JustSaying.AsyncApi/JsonSchemaNodeMapper.cs
@@ -1,0 +1,141 @@
+using System.Text.Json.Nodes;
+using ByteBard.AsyncAPI.Models;
+
+namespace JustSaying.AsyncApi;
+
+/// <summary>
+/// Maps the JSON Schema produced by <see cref="System.Text.Json.Schema.JsonSchemaExporter"/>
+/// onto the AsyncAPI schema object model.
+/// </summary>
+internal static class JsonSchemaNodeMapper
+{
+    public static AsyncApiJsonSchema Map(JsonNode node)
+    {
+        var schema = new AsyncApiJsonSchema();
+
+        // JSON Schema allows boolean schemas: "true" accepts anything, "false" accepts nothing.
+        if (node is JsonValue value && value.TryGetValue(out bool accepts))
+        {
+            if (!accepts)
+            {
+                schema.Not = new AsyncApiJsonSchema();
+            }
+
+            return schema;
+        }
+
+        if (node is not JsonObject obj)
+        {
+            return schema;
+        }
+
+        foreach (var property in obj)
+        {
+            switch (property.Key)
+            {
+                case "type":
+                    schema.Type = MapType(property.Value);
+                    break;
+                case "title":
+                    schema.Title = (string)property.Value;
+                    break;
+                case "description":
+                    schema.Description = (string)property.Value;
+                    break;
+                case "format":
+                    schema.Format = (string)property.Value;
+                    break;
+                case "pattern":
+                    schema.Pattern = (string)property.Value;
+                    break;
+                case "properties":
+                    schema.Properties = ((JsonObject)property.Value).ToDictionary((p) => p.Key, (p) => Map(p.Value));
+                    break;
+                case "patternProperties":
+                    schema.PatternProperties = ((JsonObject)property.Value).ToDictionary((p) => p.Key, (p) => Map(p.Value));
+                    break;
+                case "required":
+                    schema.Required = new HashSet<string>(((JsonArray)property.Value).Select((i) => (string)i), StringComparer.Ordinal);
+                    break;
+                case "items":
+                    schema.Items = Map(property.Value);
+                    break;
+                case "additionalProperties":
+                    schema.AdditionalProperties = Map(property.Value);
+                    break;
+                case "enum":
+                    schema.Enum = [.. ((JsonArray)property.Value).Select((i) => new AsyncApiAny(i?.DeepClone()))];
+                    break;
+                case "const":
+                    schema.Const = new AsyncApiAny(property.Value?.DeepClone());
+                    break;
+                case "default":
+                    schema.Default = new AsyncApiAny(property.Value?.DeepClone());
+                    break;
+                case "minimum":
+                    schema.Minimum = (double)property.Value;
+                    break;
+                case "maximum":
+                    schema.Maximum = (double)property.Value;
+                    break;
+                case "minLength":
+                    schema.MinLength = (int)property.Value;
+                    break;
+                case "maxLength":
+                    schema.MaxLength = (int)property.Value;
+                    break;
+                case "minItems":
+                    schema.MinItems = (int)property.Value;
+                    break;
+                case "maxItems":
+                    schema.MaxItems = (int)property.Value;
+                    break;
+                case "anyOf":
+                    schema.AnyOf = [.. ((JsonArray)property.Value).Select(Map)];
+                    break;
+                case "allOf":
+                    schema.AllOf = [.. ((JsonArray)property.Value).Select(Map)];
+                    break;
+                case "oneOf":
+                    schema.OneOf = [.. ((JsonArray)property.Value).Select(Map)];
+                    break;
+                case "not":
+                    schema.Not = Map(property.Value);
+                    break;
+                default:
+                    // Keywords the AsyncAPI model has no slot for (for example "$comment") are dropped.
+                    break;
+            }
+        }
+
+        return schema;
+    }
+
+    private static SchemaType MapType(JsonNode typeNode)
+    {
+        if (typeNode is JsonArray types)
+        {
+            SchemaType combined = 0;
+            foreach (var type in types)
+            {
+                combined |= ParseType((string)type);
+            }
+
+            return combined;
+        }
+
+        return ParseType((string)typeNode);
+    }
+
+    private static SchemaType ParseType(string type) => type switch
+    {
+        "object" => SchemaType.Object,
+        "array" => SchemaType.Array,
+        "string" => SchemaType.String,
+        "integer" => SchemaType.Integer,
+        "number" => SchemaType.Number,
+        "boolean" => SchemaType.Boolean,
+        "null" => SchemaType.Null,
+        _ => 0,
+    };
+}

--- a/src/JustSaying.AsyncApi/JsonSchemaNodeMapper.cs
+++ b/src/JustSaying.AsyncApi/JsonSchemaNodeMapper.cs
@@ -10,6 +10,9 @@ namespace JustSaying.AsyncApi;
 internal static class JsonSchemaNodeMapper
 {
     public static AsyncApiJsonSchema Map(JsonNode node)
+        => Map(node, node, new HashSet<string>(StringComparer.Ordinal));
+
+    private static AsyncApiJsonSchema Map(JsonNode node, JsonNode root, HashSet<string> activeRefs)
     {
         var schema = new AsyncApiJsonSchema();
 
@@ -27,6 +30,31 @@ internal static class JsonSchemaNodeMapper
         if (node is not JsonObject obj)
         {
             return schema;
+        }
+
+        // The schema exporter emits "$ref" as a JSON Pointer into the schema itself for recursive
+        // types (for example "#/properties/Left"). Those pointers are relative to the exported
+        // schema's root and would not resolve once embedded in the wider AsyncAPI document, so the
+        // referenced subschema is inlined instead. Cycles are broken by emitting an empty schema
+        // when a pointer refers back into a subschema that is already being expanded.
+        if (obj.TryGetPropertyValue("$ref", out var refNode)
+            && refNode is JsonValue refValue
+            && refValue.TryGetValue(out string pointer))
+        {
+            if (!activeRefs.Add(pointer))
+            {
+                return schema;
+            }
+
+            try
+            {
+                var target = ResolvePointer(root, pointer);
+                return target == null ? schema : Map(target, root, activeRefs);
+            }
+            finally
+            {
+                activeRefs.Remove(pointer);
+            }
         }
 
         foreach (var property in obj)
@@ -49,19 +77,19 @@ internal static class JsonSchemaNodeMapper
                     schema.Pattern = (string)property.Value;
                     break;
                 case "properties":
-                    schema.Properties = ((JsonObject)property.Value).ToDictionary((p) => p.Key, (p) => Map(p.Value));
+                    schema.Properties = ((JsonObject)property.Value).ToDictionary((p) => p.Key, (p) => Map(p.Value, root, activeRefs));
                     break;
                 case "patternProperties":
-                    schema.PatternProperties = ((JsonObject)property.Value).ToDictionary((p) => p.Key, (p) => Map(p.Value));
+                    schema.PatternProperties = ((JsonObject)property.Value).ToDictionary((p) => p.Key, (p) => Map(p.Value, root, activeRefs));
                     break;
                 case "required":
                     schema.Required = new HashSet<string>(((JsonArray)property.Value).Select((i) => (string)i), StringComparer.Ordinal);
                     break;
                 case "items":
-                    schema.Items = Map(property.Value);
+                    schema.Items = Map(property.Value, root, activeRefs);
                     break;
                 case "additionalProperties":
-                    schema.AdditionalProperties = Map(property.Value);
+                    schema.AdditionalProperties = Map(property.Value, root, activeRefs);
                     break;
                 case "enum":
                     schema.Enum = [.. ((JsonArray)property.Value).Select((i) => new AsyncApiAny(i?.DeepClone()))];
@@ -91,16 +119,16 @@ internal static class JsonSchemaNodeMapper
                     schema.MaxItems = (int)property.Value;
                     break;
                 case "anyOf":
-                    schema.AnyOf = [.. ((JsonArray)property.Value).Select(Map)];
+                    schema.AnyOf = [.. ((JsonArray)property.Value).Select((i) => Map(i, root, activeRefs))];
                     break;
                 case "allOf":
-                    schema.AllOf = [.. ((JsonArray)property.Value).Select(Map)];
+                    schema.AllOf = [.. ((JsonArray)property.Value).Select((i) => Map(i, root, activeRefs))];
                     break;
                 case "oneOf":
-                    schema.OneOf = [.. ((JsonArray)property.Value).Select(Map)];
+                    schema.OneOf = [.. ((JsonArray)property.Value).Select((i) => Map(i, root, activeRefs))];
                     break;
                 case "not":
-                    schema.Not = Map(property.Value);
+                    schema.Not = Map(property.Value, root, activeRefs);
                     break;
                 default:
                     // Keywords the AsyncAPI model has no slot for (for example "$comment") are dropped.
@@ -109,6 +137,40 @@ internal static class JsonSchemaNodeMapper
         }
 
         return schema;
+    }
+
+    private static JsonNode ResolvePointer(JsonNode root, string pointer)
+    {
+        if (pointer == "#")
+        {
+            return root;
+        }
+
+        if (!pointer.StartsWith("#/", StringComparison.Ordinal))
+        {
+            // The exporter only produces local JSON Pointers; anything else is not resolvable here.
+            return null;
+        }
+
+        JsonNode current = root;
+        foreach (var rawToken in pointer.Substring(2).Split('/'))
+        {
+            if (current == null)
+            {
+                return null;
+            }
+
+            // RFC 6901 escaping: "~1" is "/" and "~0" is "~".
+            string token = rawToken.Replace("~1", "/").Replace("~0", "~");
+            current = current switch
+            {
+                JsonObject o => o.TryGetPropertyValue(token, out var child) ? child : null,
+                JsonArray a => int.TryParse(token, out int index) && index >= 0 && index < a.Count ? a[index] : null,
+                _ => null,
+            };
+        }
+
+        return current;
     }
 
     private static SchemaType MapType(JsonNode typeNode)

--- a/src/JustSaying.AsyncApi/JustSaying.AsyncApi.csproj
+++ b/src/JustSaying.AsyncApi/JustSaying.AsyncApi.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="ByteBard.AsyncAPI.NET" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 </Project>

--- a/src/JustSaying.AsyncApi/JustSaying.AsyncApi.csproj
+++ b/src/JustSaying.AsyncApi/JustSaying.AsyncApi.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>AsyncAPI document generation for JustSaying.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsShipping>true</IsShipping>
+    <PackageTags>aws,sns,sqs,asyncapi</PackageTags>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\JustSaying\JustSaying.csproj" />
+    <ProjectReference Include="..\JustSaying.CloudEvents\JustSaying.CloudEvents.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ByteBard.AsyncAPI.NET" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+</Project>

--- a/src/JustSaying.AsyncApi/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/JustSaying.AsyncApi/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 JustSaying.AsyncApi.AsyncApiDocumentGenerator
-JustSaying.AsyncApi.AsyncApiDocumentGenerator.AsyncApiDocumentGenerator(JustSaying.Messaging.Metadata.IMessagingMetadataRegistry registry, JustSaying.AsyncApi.AsyncApiOptions options, JustSaying.Messaging.MessageSerialization.IMessageBodySerializationFactory serializationFactory = null, JustSaying.CloudEvents.CloudEventOptions cloudEventOptions = null) -> void
+JustSaying.AsyncApi.AsyncApiDocumentGenerator.AsyncApiDocumentGenerator(JustSaying.Messaging.Metadata.IMessagingMetadataRegistry registry, JustSaying.AsyncApi.AsyncApiOptions options, JustSaying.Messaging.MessageSerialization.IMessageBodySerializationFactory serializationFactory = null, JustSaying.CloudEvents.CloudEventOptions cloudEventOptions = null, Microsoft.Extensions.Logging.ILogger<JustSaying.AsyncApi.AsyncApiDocumentGenerator> logger = null) -> void
 JustSaying.AsyncApi.AsyncApiDocumentGenerator.Generate() -> ByteBard.AsyncAPI.Models.AsyncApiDocument
 JustSaying.AsyncApi.AsyncApiOptions
 JustSaying.AsyncApi.AsyncApiOptions.AsyncApiOptions() -> void

--- a/src/JustSaying.AsyncApi/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/JustSaying.AsyncApi/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,22 @@
+JustSaying.AsyncApi.AsyncApiDocumentGenerator
+JustSaying.AsyncApi.AsyncApiDocumentGenerator.AsyncApiDocumentGenerator(JustSaying.Messaging.Metadata.IMessagingMetadataRegistry registry, JustSaying.AsyncApi.AsyncApiOptions options, JustSaying.Messaging.MessageSerialization.IMessageBodySerializationFactory serializationFactory = null, JustSaying.CloudEvents.CloudEventOptions cloudEventOptions = null) -> void
+JustSaying.AsyncApi.AsyncApiDocumentGenerator.Generate() -> ByteBard.AsyncAPI.Models.AsyncApiDocument
+JustSaying.AsyncApi.AsyncApiOptions
+JustSaying.AsyncApi.AsyncApiOptions.AsyncApiOptions() -> void
+JustSaying.AsyncApi.AsyncApiOptions.Description.get -> string
+JustSaying.AsyncApi.AsyncApiOptions.Description.set -> void
+JustSaying.AsyncApi.AsyncApiOptions.Id.get -> string
+JustSaying.AsyncApi.AsyncApiOptions.Id.set -> void
+JustSaying.AsyncApi.AsyncApiOptions.PostProcess.get -> System.Action<ByteBard.AsyncAPI.Models.AsyncApiDocument>
+JustSaying.AsyncApi.AsyncApiOptions.PostProcess.set -> void
+JustSaying.AsyncApi.AsyncApiOptions.SerializerOptions.get -> System.Text.Json.JsonSerializerOptions
+JustSaying.AsyncApi.AsyncApiOptions.SerializerOptions.set -> void
+JustSaying.AsyncApi.AsyncApiOptions.Title.get -> string
+JustSaying.AsyncApi.AsyncApiOptions.Title.set -> void
+JustSaying.AsyncApi.AsyncApiOptions.Version.get -> string
+JustSaying.AsyncApi.AsyncApiOptions.Version.set -> void
+JustSaying.AsyncApi.IAsyncApiDocumentProvider
+JustSaying.AsyncApi.IAsyncApiDocumentProvider.GenerateAsync(string documentName, System.IO.TextWriter writer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+JustSaying.AsyncApi.IAsyncApiDocumentProvider.GetDocumentNames() -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Extensions.DependencyInjection.AsyncApiServiceCollectionExtensions
+static Microsoft.Extensions.DependencyInjection.AsyncApiServiceCollectionExtensions.AddJustSayingAsyncApi(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<JustSaying.AsyncApi.AsyncApiOptions> configure = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection

--- a/src/JustSaying.AsyncApi/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/JustSaying.AsyncApi/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 JustSaying.AsyncApi.AsyncApiDocumentGenerator
-JustSaying.AsyncApi.AsyncApiDocumentGenerator.AsyncApiDocumentGenerator(JustSaying.Messaging.Metadata.IMessagingMetadataRegistry registry, JustSaying.AsyncApi.AsyncApiOptions options, JustSaying.Messaging.MessageSerialization.IMessageBodySerializationFactory serializationFactory = null, JustSaying.CloudEvents.CloudEventOptions cloudEventOptions = null, Microsoft.Extensions.Logging.ILogger<JustSaying.AsyncApi.AsyncApiDocumentGenerator> logger = null) -> void
+JustSaying.AsyncApi.AsyncApiDocumentGenerator.AsyncApiDocumentGenerator(JustSaying.Messaging.Metadata.IMessagingMetadataRegistry registry, JustSaying.AsyncApi.AsyncApiOptions options, JustSaying.Messaging.MessageSerialization.IMessageBodySerializationFactory serializationFactory = null, Microsoft.Extensions.Logging.ILogger<JustSaying.AsyncApi.AsyncApiDocumentGenerator> logger = null) -> void
 JustSaying.AsyncApi.AsyncApiDocumentGenerator.Generate() -> ByteBard.AsyncAPI.Models.AsyncApiDocument
 JustSaying.AsyncApi.AsyncApiOptions
 JustSaying.AsyncApi.AsyncApiOptions.AsyncApiOptions() -> void

--- a/src/JustSaying.CloudEvents/CloudEventEnvelopeBodySerializer`1.cs
+++ b/src/JustSaying.CloudEvents/CloudEventEnvelopeBodySerializer`1.cs
@@ -13,7 +13,7 @@ namespace JustSaying.CloudEvents;
 /// handled by an inner <see cref="IMessageBodySerializer{TMessage}"/>.
 /// </summary>
 /// <typeparam name="T">The type of the <c>data</c> payload.</typeparam>
-public sealed class CloudEventEnvelopeBodySerializer<T> : IMessageBodySerializer<CloudEvent<T>>, ISelfDescribingMessageBodySerializer
+public sealed class CloudEventEnvelopeBodySerializer<T> : IMessageBodySerializer<CloudEvent<T>>, ISelfDescribingMessageBodySerializer, ICloudEventMessageBodySerializer
     where T : class
 {
     private const string SpecVersion = "1.0";
@@ -29,6 +29,21 @@ public sealed class CloudEventEnvelopeBodySerializer<T> : IMessageBodySerializer
     private readonly Uri _source;
     private readonly string _type;
     private readonly string _dataContentType;
+
+    /// <inheritdoc />
+    public string Type => _type;
+
+    /// <inheritdoc />
+    public Uri Source => _source;
+
+    /// <inheritdoc />
+    public string DataContentType => _dataContentType;
+
+    /// <inheritdoc />
+    public System.Type DataType => typeof(T);
+
+    /// <inheritdoc />
+    public object DataSerializer => _dataSerializer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CloudEventEnvelopeBodySerializer{T}"/> class.

--- a/src/JustSaying.CloudEvents/CloudEventMessageBodySerializer`1.cs
+++ b/src/JustSaying.CloudEvents/CloudEventMessageBodySerializer`1.cs
@@ -13,7 +13,7 @@ namespace JustSaying.CloudEvents;
 /// serialized by an inner <see cref="IMessageBodySerializer{TMessage}"/>.
 /// </summary>
 /// <typeparam name="TMessage">The type of message to be serialized or deserialized.</typeparam>
-public sealed class CloudEventMessageBodySerializer<TMessage> : IMessageBodySerializer<TMessage>, ISelfDescribingMessageBodySerializer where TMessage : class
+public sealed class CloudEventMessageBodySerializer<TMessage> : IMessageBodySerializer<TMessage>, ISelfDescribingMessageBodySerializer, ICloudEventMessageBodySerializer where TMessage : class
 {
     private const string SpecVersion = "1.0";
 
@@ -22,6 +22,21 @@ public sealed class CloudEventMessageBodySerializer<TMessage> : IMessageBodySeri
     private readonly Uri _source;
     private readonly string _type;
     private readonly string _dataContentType;
+
+    /// <inheritdoc />
+    public string Type => _type;
+
+    /// <inheritdoc />
+    public Uri Source => _source;
+
+    /// <inheritdoc />
+    public string DataContentType => _dataContentType;
+
+    /// <inheritdoc />
+    public System.Type DataType => typeof(TMessage);
+
+    /// <inheritdoc />
+    public object DataSerializer => _dataSerializer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CloudEventMessageBodySerializer{TMessage}"/> class.

--- a/src/JustSaying.CloudEvents/CloudEventOptions.cs
+++ b/src/JustSaying.CloudEvents/CloudEventOptions.cs
@@ -34,5 +34,11 @@ public sealed class CloudEventOptions
         return this;
     }
 
-    internal bool TryGetCloudEventType(Type messageType, out string type) => _typeNames.TryGetValue(messageType, out type);
+    /// <summary>
+    /// Gets the CloudEvents <c>type</c> attribute registered for a message type, if any.
+    /// </summary>
+    /// <param name="messageType">The message type to look up.</param>
+    /// <param name="type">The registered CloudEvents <c>type</c>, or <see langword="null"/> if none is registered.</param>
+    /// <returns><see langword="true"/> if a CloudEvents <c>type</c> is registered for <paramref name="messageType"/>.</returns>
+    public bool TryGetCloudEventType(Type messageType, out string type) => _typeNames.TryGetValue(messageType, out type);
 }

--- a/src/JustSaying.CloudEvents/CloudEventOptions.cs
+++ b/src/JustSaying.CloudEvents/CloudEventOptions.cs
@@ -34,11 +34,5 @@ public sealed class CloudEventOptions
         return this;
     }
 
-    /// <summary>
-    /// Gets the CloudEvents <c>type</c> attribute registered for a message type, if any.
-    /// </summary>
-    /// <param name="messageType">The message type to look up.</param>
-    /// <param name="type">The registered CloudEvents <c>type</c>, or <see langword="null"/> if none is registered.</param>
-    /// <returns><see langword="true"/> if a CloudEvents <c>type</c> is registered for <paramref name="messageType"/>.</returns>
-    public bool TryGetCloudEventType(Type messageType, out string type) => _typeNames.TryGetValue(messageType, out type);
+    internal bool TryGetCloudEventType(Type messageType, out string type) => _typeNames.TryGetValue(messageType, out type);
 }

--- a/src/JustSaying.CloudEvents/CloudEventSerializationFactory.cs
+++ b/src/JustSaying.CloudEvents/CloudEventSerializationFactory.cs
@@ -34,12 +34,6 @@ public sealed class CloudEventSerializationFactory : IMessageBodySerializationFa
         // message is actually serialized for publishing.
     }
 
-    /// <summary>
-    /// Gets the factory whose serializers handle the CloudEvents <c>data</c> payload,
-    /// which describes the wire contract of the payload, for example for schema generation.
-    /// </summary>
-    public IMessageBodySerializationFactory DataSerializerFactory => _dataSerializerFactory;
-
     /// <inheritdoc />
     public IMessageBodySerializer<TMessage> GetSerializer<TMessage>() where TMessage : class
     {

--- a/src/JustSaying.CloudEvents/CloudEventSerializationFactory.cs
+++ b/src/JustSaying.CloudEvents/CloudEventSerializationFactory.cs
@@ -34,6 +34,12 @@ public sealed class CloudEventSerializationFactory : IMessageBodySerializationFa
         // message is actually serialized for publishing.
     }
 
+    /// <summary>
+    /// Gets the factory whose serializers handle the CloudEvents <c>data</c> payload,
+    /// which describes the wire contract of the payload, for example for schema generation.
+    /// </summary>
+    public IMessageBodySerializationFactory DataSerializerFactory => _dataSerializerFactory;
+
     /// <inheritdoc />
     public IMessageBodySerializer<TMessage> GetSerializer<TMessage>() where TMessage : class
     {

--- a/src/JustSaying.CloudEvents/CloudEventsServiceCollectionExtensions.cs
+++ b/src/JustSaying.CloudEvents/CloudEventsServiceCollectionExtensions.cs
@@ -53,6 +53,8 @@ public static class CloudEventsServiceCollectionExtensions
         var options = new CloudEventOptions();
         configure?.Invoke(options);
 
+        services.TryAddSingleton(options);
+
         services.TryAddSingleton(serviceProvider =>
         {
             var config = serviceProvider.GetRequiredService<IMessagingConfig>();

--- a/src/JustSaying.CloudEvents/CloudEventsServiceCollectionExtensions.cs
+++ b/src/JustSaying.CloudEvents/CloudEventsServiceCollectionExtensions.cs
@@ -53,8 +53,6 @@ public static class CloudEventsServiceCollectionExtensions
         var options = new CloudEventOptions();
         configure?.Invoke(options);
 
-        services.TryAddSingleton(options);
-
         services.TryAddSingleton(serviceProvider =>
         {
             var config = serviceProvider.GetRequiredService<IMessagingConfig>();

--- a/src/JustSaying.CloudEvents/ICloudEventMessageBodySerializer.cs
+++ b/src/JustSaying.CloudEvents/ICloudEventMessageBodySerializer.cs
@@ -1,0 +1,37 @@
+namespace JustSaying.CloudEvents;
+
+/// <summary>
+/// Implemented by the CloudEvents serializers to describe the structured-mode envelope they write,
+/// so that tooling (such as AsyncAPI document generation) can document a registration's wire format
+/// from the serializer it actually uses rather than from application-wide configuration.
+/// </summary>
+public interface ICloudEventMessageBodySerializer
+{
+    /// <summary>
+    /// Gets the CloudEvents <c>type</c> written to the envelope, or <see langword="null"/> when the
+    /// serializer is only used to consume and none is configured.
+    /// </summary>
+    string Type { get; }
+
+    /// <summary>
+    /// Gets the default CloudEvents <c>source</c> written to the envelope, or <see langword="null"/>
+    /// when none is configured (a published <see cref="CloudEvent{T}"/> may still carry its own).
+    /// </summary>
+    Uri Source { get; }
+
+    /// <summary>
+    /// Gets the CloudEvents <c>datacontenttype</c> written to the envelope.
+    /// </summary>
+    string DataContentType { get; }
+
+    /// <summary>
+    /// Gets the CLR type of the <c>data</c> payload.
+    /// </summary>
+    Type DataType { get; }
+
+    /// <summary>
+    /// Gets the serializer — an <c>IMessageBodySerializer&lt;T&gt;</c> for <see cref="DataType"/> —
+    /// that produces the envelope's <c>data</c> member.
+    /// </summary>
+    object DataSerializer { get; }
+}

--- a/src/JustSaying.CloudEvents/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/JustSaying.CloudEvents/PublicAPI/PublicAPI.Unshipped.txt
@@ -44,3 +44,5 @@ static JustSaying.Fluent.PublicationsBuilderCloudEventExtensions.WithCloudEventT
 static JustSaying.Fluent.PublicationsBuilderCloudEventExtensions.WithCloudEventTopic<T>(this JustSaying.Fluent.PublicationsBuilder publications, JustSaying.Fluent.TopicDestination destination, string type, System.Uri source) -> JustSaying.Fluent.PublicationsBuilder
 static JustSaying.Fluent.PublicationsBuilderCloudEventExtensions.WithCloudEventQueue<T>(this JustSaying.Fluent.PublicationsBuilder publications, JustSaying.Fluent.QueueDestination destination, string type) -> JustSaying.Fluent.PublicationsBuilder
 static JustSaying.Fluent.PublicationsBuilderCloudEventExtensions.WithCloudEventQueue<T>(this JustSaying.Fluent.PublicationsBuilder publications, JustSaying.Fluent.QueueDestination destination, string type, System.Uri source) -> JustSaying.Fluent.PublicationsBuilder
+JustSaying.CloudEvents.CloudEventOptions.TryGetCloudEventType(System.Type messageType, out string type) -> bool
+JustSaying.CloudEvents.CloudEventSerializationFactory.DataSerializerFactory.get -> JustSaying.Messaging.MessageSerialization.IMessageBodySerializationFactory

--- a/src/JustSaying.CloudEvents/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/JustSaying.CloudEvents/PublicAPI/PublicAPI.Unshipped.txt
@@ -44,5 +44,19 @@ static JustSaying.Fluent.PublicationsBuilderCloudEventExtensions.WithCloudEventT
 static JustSaying.Fluent.PublicationsBuilderCloudEventExtensions.WithCloudEventTopic<T>(this JustSaying.Fluent.PublicationsBuilder publications, JustSaying.Fluent.TopicDestination destination, string type, System.Uri source) -> JustSaying.Fluent.PublicationsBuilder
 static JustSaying.Fluent.PublicationsBuilderCloudEventExtensions.WithCloudEventQueue<T>(this JustSaying.Fluent.PublicationsBuilder publications, JustSaying.Fluent.QueueDestination destination, string type) -> JustSaying.Fluent.PublicationsBuilder
 static JustSaying.Fluent.PublicationsBuilderCloudEventExtensions.WithCloudEventQueue<T>(this JustSaying.Fluent.PublicationsBuilder publications, JustSaying.Fluent.QueueDestination destination, string type, System.Uri source) -> JustSaying.Fluent.PublicationsBuilder
-JustSaying.CloudEvents.CloudEventOptions.TryGetCloudEventType(System.Type messageType, out string type) -> bool
-JustSaying.CloudEvents.CloudEventSerializationFactory.DataSerializerFactory.get -> JustSaying.Messaging.MessageSerialization.IMessageBodySerializationFactory
+JustSaying.CloudEvents.ICloudEventMessageBodySerializer
+JustSaying.CloudEvents.ICloudEventMessageBodySerializer.DataContentType.get -> string
+JustSaying.CloudEvents.ICloudEventMessageBodySerializer.DataSerializer.get -> object
+JustSaying.CloudEvents.ICloudEventMessageBodySerializer.DataType.get -> System.Type
+JustSaying.CloudEvents.ICloudEventMessageBodySerializer.Source.get -> System.Uri
+JustSaying.CloudEvents.ICloudEventMessageBodySerializer.Type.get -> string
+JustSaying.CloudEvents.CloudEventMessageBodySerializer<TMessage>.DataContentType.get -> string
+JustSaying.CloudEvents.CloudEventMessageBodySerializer<TMessage>.DataSerializer.get -> object
+JustSaying.CloudEvents.CloudEventMessageBodySerializer<TMessage>.DataType.get -> System.Type
+JustSaying.CloudEvents.CloudEventMessageBodySerializer<TMessage>.Source.get -> System.Uri
+JustSaying.CloudEvents.CloudEventMessageBodySerializer<TMessage>.Type.get -> string
+JustSaying.CloudEvents.CloudEventEnvelopeBodySerializer<T>.DataContentType.get -> string
+JustSaying.CloudEvents.CloudEventEnvelopeBodySerializer<T>.DataSerializer.get -> object
+JustSaying.CloudEvents.CloudEventEnvelopeBodySerializer<T>.DataType.get -> System.Type
+JustSaying.CloudEvents.CloudEventEnvelopeBodySerializer<T>.Source.get -> System.Uri
+JustSaying.CloudEvents.CloudEventEnvelopeBodySerializer<T>.Type.get -> string

--- a/src/JustSaying/AwsTools/DefaultAwsClientFactory.cs
+++ b/src/JustSaying/AwsTools/DefaultAwsClientFactory.cs
@@ -1,6 +1,5 @@
 using Amazon;
 using Amazon.Runtime;
-using Amazon.Runtime.Credentials;
 using Amazon.SimpleNotificationService;
 using Amazon.SQS;
 
@@ -12,7 +11,9 @@ public class DefaultAwsClientFactory : IAwsClientFactory
 
     public DefaultAwsClientFactory()
     {
-        _credentials = DefaultAWSCredentialsIdentityResolver.GetCredentials();
+        // With no explicit credentials the clients resolve the default credential chain when the
+        // first request is made, so creating clients (and building the bus) works on machines
+        // with no resolvable credentials, such as generating an AsyncAPI document on CI.
     }
 
     public DefaultAwsClientFactory(AWSCredentials customCredentials)
@@ -23,10 +24,14 @@ public class DefaultAwsClientFactory : IAwsClientFactory
     public Uri ServiceUri { get; set; }
 
     public IAmazonSimpleNotificationService GetSnsClient(RegionEndpoint region)
-        => new AmazonSimpleNotificationServiceClient(_credentials, CreateSNSConfig(region));
+        => _credentials is null
+            ? new AmazonSimpleNotificationServiceClient(CreateSNSConfig(region))
+            : new AmazonSimpleNotificationServiceClient(_credentials, CreateSNSConfig(region));
 
     public IAmazonSQS GetSqsClient(RegionEndpoint region)
-        => new AmazonSQSClient(_credentials, CreateSQSConfig(region));
+        => _credentials is null
+            ? new AmazonSQSClient(CreateSQSConfig(region))
+            : new AmazonSQSClient(_credentials, CreateSQSConfig(region));
 
     protected virtual void Configure(AmazonSimpleNotificationServiceConfig config)
     {

--- a/src/JustSaying/Fluent/MultiTypeQueueSubscriptionBuilder.cs
+++ b/src/JustSaying/Fluent/MultiTypeQueueSubscriptionBuilder.cs
@@ -234,9 +234,11 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
         }
 
         var serializersByName = new Dictionary<string, IMessageBodySerializer>(StringComparer.Ordinal);
+        var serializersByRegistration = new Dictionary<IMessageTypeRegistration, object>();
         foreach (var registration in _registrations)
         {
-            serializersByName[namesByRegistration[registration]] = registration.CreateErasedSerializer(bus, serviceResolver);
+            serializersByName[namesByRegistration[registration]] = registration.CreateErasedSerializer(bus, serviceResolver, out var serializer);
+            serializersByRegistration[registration] = serializer;
             registration.RegisterHandler(bus, handlerResolver, serviceResolver, queueName);
         }
 
@@ -266,7 +268,7 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
                 topicName: null,
                 _subscriptionGroupName ?? queueName,
                 _rawMessageDelivery,
-                [.. _registrations.Select((r) => new MessageTypeMetadata(r.MessageType, namesByRegistration[r]))],
+                [.. _registrations.Select((r) => new MessageTypeMetadata(r.MessageType, namesByRegistration[r], serializersByRegistration[r]))],
                 queueRegion));
         }
 
@@ -282,7 +284,12 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
 
         string ResolveTypeName(JustSayingBus bus, IServiceResolver serviceResolver);
 
-        IMessageBodySerializer CreateErasedSerializer(JustSayingBus bus, IServiceResolver serviceResolver);
+        /// <summary>
+        /// Creates the serializer for this registration's message type, returning the type-erased
+        /// view used to deserialize inbound bodies and, via <paramref name="serializer"/>, the
+        /// typed instance itself so the registration can be described (for example for AsyncAPI).
+        /// </summary>
+        IMessageBodySerializer CreateErasedSerializer(JustSayingBus bus, IServiceResolver serviceResolver, out object serializer);
 
         void RegisterHandler(JustSayingBus bus, IHandlerResolver handlerResolver, IServiceResolver serviceResolver, string queueName);
     }
@@ -303,10 +310,15 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
                ?? typeNameResolver?.Invoke(serviceResolver)
                ?? bus.MessageTypeRegistry.GetLogicalName(typeof(TMessage));
 
-        public IMessageBodySerializer CreateErasedSerializer(JustSayingBus bus, IServiceResolver serviceResolver)
-            => (serializerFactory is null
+        public IMessageBodySerializer CreateErasedSerializer(JustSayingBus bus, IServiceResolver serviceResolver, out object serializer)
+        {
+            var typed = serializerFactory is null
                 ? bus.MessageBodySerializerFactory.GetSerializer<TMessage>()
-                : serializerFactory(serviceResolver)).Erase();
+                : serializerFactory(serviceResolver);
+
+            serializer = typed;
+            return typed.Erase();
+        }
 
         public void RegisterHandler(JustSayingBus bus, IHandlerResolver handlerResolver, IServiceResolver serviceResolver, string queueName)
         {

--- a/src/JustSaying/Fluent/MultiTypeQueueSubscriptionBuilder.cs
+++ b/src/JustSaying/Fluent/MultiTypeQueueSubscriptionBuilder.cs
@@ -4,6 +4,7 @@ using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging;
 using JustSaying.Messaging.Channels.SubscriptionGroups;
 using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Metadata;
 using JustSaying.Messaging.Middleware;
 using Microsoft.Extensions.Logging;
 
@@ -195,6 +196,7 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
 
         ISqsQueue sqsQueue;
         string queueName;
+        string region;
         if (_destination.IsAddress)
         {
             // A pre-existing queue: never created, so only the read-time settings apply.
@@ -205,6 +207,7 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
             var queue = new QueueAddressQueue(_destination.Address, sqsClient);
             sqsQueue = queue;
             queueName = queue.QueueName;
+            region = _destination.Address.RegionName;
         }
         else
         {
@@ -222,7 +225,7 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
             subscriptionConfig.Validate();
 
             var config = bus.Config;
-            var region = config.Region ?? throw new InvalidOperationException($"Config cannot have a blank entry for the {nameof(config.Region)} property.");
+            region = config.Region ?? throw new InvalidOperationException($"Config cannot have a blank entry for the {nameof(config.Region)} property.");
 
             var queue = creator.EnsureQueueExists(region, subscriptionConfig);
             bus.AddStartupTask(queue.StartupTask);
@@ -247,6 +250,18 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
             MessageConverter = new InboundMessageConverter(serializerResolver, bus.CompressionRegistry, _rawMessageDelivery),
             SqsQueue = sqsQueue,
         });
+
+        var metadataRegistry = serviceResolver.ResolveOptionalService<IMessagingMetadataRegistry>();
+        if (metadataRegistry != null)
+        {
+            metadataRegistry.SetRegion(region);
+            metadataRegistry.AddSubscription(new SubscriptionMetadata(
+                queueName,
+                topicName: null,
+                _subscriptionGroupName ?? queueName,
+                _rawMessageDelivery,
+                [.. _registrations.Select((r) => new MessageTypeMetadata(r.MessageType, namesByRegistration[r]))]));
+        }
 
         logger.LogInformation(
             "Created multi-type SQS subscriber on queue '{QueueName}' handling {MessageTypeCount} message types.",

--- a/src/JustSaying/Fluent/MultiTypeQueueSubscriptionBuilder.cs
+++ b/src/JustSaying/Fluent/MultiTypeQueueSubscriptionBuilder.cs
@@ -196,7 +196,7 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
 
         ISqsQueue sqsQueue;
         string queueName;
-        string region;
+        string queueRegion = null;
         if (_destination.IsAddress)
         {
             // A pre-existing queue: never created, so only the read-time settings apply.
@@ -207,7 +207,7 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
             var queue = new QueueAddressQueue(_destination.Address, sqsClient);
             sqsQueue = queue;
             queueName = queue.QueueName;
-            region = _destination.Address.RegionName;
+            queueRegion = _destination.Address.RegionName;
         }
         else
         {
@@ -225,7 +225,7 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
             subscriptionConfig.Validate();
 
             var config = bus.Config;
-            region = config.Region ?? throw new InvalidOperationException($"Config cannot have a blank entry for the {nameof(config.Region)} property.");
+            var region = config.Region ?? throw new InvalidOperationException($"Config cannot have a blank entry for the {nameof(config.Region)} property.");
 
             var queue = creator.EnsureQueueExists(region, subscriptionConfig);
             bus.AddStartupTask(queue.StartupTask);
@@ -254,13 +254,20 @@ public sealed class MultiTypeQueueSubscriptionBuilder : ISubscriptionBuilder<obj
         var metadataRegistry = serviceResolver.ResolveOptionalService<IMessagingMetadataRegistry>();
         if (metadataRegistry != null)
         {
-            metadataRegistry.SetRegion(region);
+            if (queueRegion is null)
+            {
+                metadataRegistry.SetRegion(bus.Config.Region);
+            }
+
+            // A queue addressed by URL or ARN carries its own region, which may differ from the bus's
+            // configured region, so it is captured on the subscription rather than as the registry default.
             metadataRegistry.AddSubscription(new SubscriptionMetadata(
                 queueName,
                 topicName: null,
                 _subscriptionGroupName ?? queueName,
                 _rawMessageDelivery,
-                [.. _registrations.Select((r) => new MessageTypeMetadata(r.MessageType, namesByRegistration[r]))]));
+                [.. _registrations.Select((r) => new MessageTypeMetadata(r.MessageType, namesByRegistration[r]))],
+                queueRegion));
         }
 
         logger.LogInformation(

--- a/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
@@ -4,6 +4,7 @@ using JustSaying.AwsTools.MessageHandling;
 using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging;
 using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Metadata;
 using JustSaying.Messaging.Middleware;
 using Microsoft.Extensions.Logging;
 
@@ -190,13 +191,15 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T> where T 
                 typeof(T));
         }
 
+        var metadataRegistry = serviceResolver.ResolveOptionalService<IMessagingMetadataRegistry>();
+
         if (_destination.IsAddress)
         {
-            ConfigureForAddress(bus, proxy, loggerFactory, logger, compressionRegistry, compressionOptions, subject, serializer, isRawMessage);
+            ConfigureForAddress(bus, proxy, loggerFactory, logger, compressionRegistry, compressionOptions, subject, serializer, isRawMessage, metadataRegistry);
         }
         else
         {
-            ConfigureForOwnedQueue(bus, proxy, loggerFactory, logger, compressionRegistry, compressionOptions, subject, serializer, isRawMessage);
+            ConfigureForOwnedQueue(bus, proxy, loggerFactory, logger, compressionRegistry, compressionOptions, subject, serializer, isRawMessage, metadataRegistry);
         }
 
         if (MiddlewareConfiguration != null)
@@ -216,7 +219,8 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T> where T 
         PublishCompressionOptions compressionOptions,
         string subject,
         IMessageBodySerializer<T> serializer,
-        bool isRawMessage)
+        bool isRawMessage,
+        IMessagingMetadataRegistry metadataRegistry)
     {
         if (_shouldCheckQueueExistence)
         {
@@ -289,6 +293,16 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T> where T 
 
         bus.AddMessagePublisher<T>(eventPublisher);
 
+        if (metadataRegistry != null)
+        {
+            metadataRegistry.SetRegion(region);
+            metadataRegistry.AddPublication(new PublicationMetadata(
+                MessagingDestinationKind.SqsQueue,
+                writeConfiguration.QueueName,
+                isDynamic: false,
+                [new MessageTypeMetadata(typeof(T), subject)]));
+        }
+
         logger.LogInformation(
             "Created SQS publisher for message type '{MessageType}' on queue '{QueueName}'.",
             typeof(T),
@@ -304,7 +318,8 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T> where T 
         PublishCompressionOptions compressionOptions,
         string subject,
         IMessageBodySerializer<T> serializer,
-        bool isRawMessage)
+        bool isRawMessage,
+        IMessagingMetadataRegistry metadataRegistry)
     {
         if (QueueName is not null)
         {
@@ -338,6 +353,16 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T> where T 
         };
 
         bus.AddMessagePublisher<T>(eventPublisher);
+
+        if (metadataRegistry != null)
+        {
+            metadataRegistry.SetRegion(queueAddress.RegionName);
+            metadataRegistry.AddPublication(new PublicationMetadata(
+                MessagingDestinationKind.SqsQueue,
+                queueAddress.QueueUrl.Segments[queueAddress.QueueUrl.Segments.Length - 1].TrimEnd('/'),
+                isDynamic: false,
+                [new MessageTypeMetadata(typeof(T), subject)]));
+        }
 
         logger.LogInformation(
             "Created SQS queue publisher on queue URL '{QueueName}' for message type '{MessageType}'",

--- a/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
@@ -300,7 +300,8 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T> where T 
                 MessagingDestinationKind.SqsQueue,
                 writeConfiguration.QueueName,
                 isDynamic: false,
-                [new MessageTypeMetadata(typeof(T), subject)]));
+                [new MessageTypeMetadata(typeof(T), subject)],
+                usesQueueEnvelope: !isRawMessage));
         }
 
         logger.LogInformation(
@@ -363,7 +364,8 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T> where T 
                 queueAddress.QueueUrl.Segments[queueAddress.QueueUrl.Segments.Length - 1].TrimEnd('/'),
                 isDynamic: false,
                 [new MessageTypeMetadata(typeof(T), subject)],
-                queueAddress.RegionName));
+                queueAddress.RegionName,
+                usesQueueEnvelope: !isRawMessage));
         }
 
         logger.LogInformation(

--- a/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
@@ -300,7 +300,7 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T> where T 
                 MessagingDestinationKind.SqsQueue,
                 writeConfiguration.QueueName,
                 isDynamic: false,
-                [new MessageTypeMetadata(typeof(T), subject)],
+                [new MessageTypeMetadata(typeof(T), subject, serializer)],
                 usesQueueEnvelope: !isRawMessage));
         }
 
@@ -363,7 +363,7 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T> where T 
                 MessagingDestinationKind.SqsQueue,
                 queueAddress.QueueUrl.Segments[queueAddress.QueueUrl.Segments.Length - 1].TrimEnd('/'),
                 isDynamic: false,
-                [new MessageTypeMetadata(typeof(T), subject)],
+                [new MessageTypeMetadata(typeof(T), subject, serializer)],
                 queueAddress.RegionName,
                 usesQueueEnvelope: !isRawMessage));
         }

--- a/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
@@ -356,12 +356,14 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T> where T 
 
         if (metadataRegistry != null)
         {
-            metadataRegistry.SetRegion(queueAddress.RegionName);
+            // The queue's region comes from its address and may differ from the bus's configured
+            // region, so it is captured on the publication rather than as the registry default.
             metadataRegistry.AddPublication(new PublicationMetadata(
                 MessagingDestinationKind.SqsQueue,
                 queueAddress.QueueUrl.Segments[queueAddress.QueueUrl.Segments.Length - 1].TrimEnd('/'),
                 isDynamic: false,
-                [new MessageTypeMetadata(typeof(T), subject)]));
+                [new MessageTypeMetadata(typeof(T), subject)],
+                queueAddress.RegionName));
         }
 
         logger.LogInformation(

--- a/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
@@ -160,7 +160,7 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T> where 
 
         AwsTools.MessageHandling.ISqsQueue sqsQueue;
         string queueName;
-        string region;
+        string queueRegion = null;
 
         if (_destination.IsAddress)
         {
@@ -190,7 +190,7 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T> where 
 
             sqsQueue = queue;
             queueName = queue.QueueName;
-            region = _destination.Address.RegionName;
+            queueRegion = _destination.Address.RegionName;
         }
         else
         {
@@ -216,7 +216,7 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T> where 
             _destination.Infrastructure?.Apply(subscriptionConfig);
 
             var config = bus.Config;
-            region = config.Region ?? throw new InvalidOperationException($"Config cannot have a blank entry for the {nameof(config.Region)} property.");
+            var region = config.Region ?? throw new InvalidOperationException($"Config cannot have a blank entry for the {nameof(config.Region)} property.");
 
             subscriptionConfig.ApplyTopicNamingConvention<T>(config.TopicNamingConvention);
             subscriptionConfig.ApplyQueueNamingConvention<T>(config.QueueNamingConvention);
@@ -254,13 +254,20 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T> where 
         var metadataRegistry = serviceResolver.ResolveOptionalService<IMessagingMetadataRegistry>();
         if (metadataRegistry != null)
         {
-            metadataRegistry.SetRegion(region);
+            if (queueRegion is null)
+            {
+                metadataRegistry.SetRegion(bus.Config.Region);
+            }
+
+            // A queue addressed by URL or ARN carries its own region, which may differ from the bus's
+            // configured region, so it is captured on the subscription rather than as the registry default.
             metadataRegistry.AddSubscription(new SubscriptionMetadata(
                 queueName,
                 topicName: null,
                 SubscriptionGroupName ?? queueName,
                 RawMessageDelivery,
-                [new MessageTypeMetadata(typeof(T), bus.MessageTypeRegistry.GetLogicalName(typeof(T)))]));
+                [new MessageTypeMetadata(typeof(T), bus.MessageTypeRegistry.GetLogicalName(typeof(T)))],
+                queueRegion));
         }
 
         logger.LogInformation(

--- a/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
@@ -266,7 +266,7 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T> where 
                 topicName: null,
                 SubscriptionGroupName ?? queueName,
                 RawMessageDelivery,
-                [new MessageTypeMetadata(typeof(T), bus.MessageTypeRegistry.GetLogicalName(typeof(T)))],
+                [new MessageTypeMetadata(typeof(T), bus.MessageTypeRegistry.GetLogicalName(typeof(T)), serializer)],
                 queueRegion));
         }
 

--- a/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
@@ -4,6 +4,7 @@ using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging;
 using JustSaying.Messaging.Channels.SubscriptionGroups;
 using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Metadata;
 using JustSaying.Messaging.Middleware;
 using JustSaying.Models;
 using JustSaying.Naming;
@@ -159,6 +160,7 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T> where 
 
         AwsTools.MessageHandling.ISqsQueue sqsQueue;
         string queueName;
+        string region;
 
         if (_destination.IsAddress)
         {
@@ -188,6 +190,7 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T> where 
 
             sqsQueue = queue;
             queueName = queue.QueueName;
+            region = _destination.Address.RegionName;
         }
         else
         {
@@ -213,7 +216,7 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T> where 
             _destination.Infrastructure?.Apply(subscriptionConfig);
 
             var config = bus.Config;
-            var region = config.Region ?? throw new InvalidOperationException($"Config cannot have a blank entry for the {nameof(config.Region)} property.");
+            region = config.Region ?? throw new InvalidOperationException($"Config cannot have a blank entry for the {nameof(config.Region)} property.");
 
             subscriptionConfig.ApplyTopicNamingConvention<T>(config.TopicNamingConvention);
             subscriptionConfig.ApplyQueueNamingConvention<T>(config.QueueNamingConvention);
@@ -247,6 +250,18 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T> where 
             .Build();
 
         bus.AddMessageMiddleware<T>(queueName, handlerMiddleware);
+
+        var metadataRegistry = serviceResolver.ResolveOptionalService<IMessagingMetadataRegistry>();
+        if (metadataRegistry != null)
+        {
+            metadataRegistry.SetRegion(region);
+            metadataRegistry.AddSubscription(new SubscriptionMetadata(
+                queueName,
+                topicName: null,
+                SubscriptionGroupName ?? queueName,
+                RawMessageDelivery,
+                [new MessageTypeMetadata(typeof(T), bus.MessageTypeRegistry.GetLogicalName(typeof(T)))]));
+        }
 
         logger.LogInformation(
             "Added a message handler for message type for '{MessageType}' on queue '{QueueName}'.",

--- a/src/JustSaying/Fluent/TopicPublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicPublicationBuilder`1.cs
@@ -371,12 +371,14 @@ public sealed class TopicPublicationBuilder<T> : IPublicationBuilder<T> where T 
         var metadataRegistry = _serviceResolver.ResolveOptionalService<IMessagingMetadataRegistry>();
         if (metadataRegistry != null)
         {
-            metadataRegistry.SetRegion(arn.Region);
+            // The topic's region comes from its ARN and may differ from the bus's configured
+            // region, so it is captured on the publication rather than as the registry default.
             metadataRegistry.AddPublication(new PublicationMetadata(
                 MessagingDestinationKind.SnsTopic,
                 TopicAddressCustomizer != null ? null : arn.Resource,
                 isDynamic: TopicAddressCustomizer != null,
-                [new MessageTypeMetadata(typeof(T), subject)]));
+                [new MessageTypeMetadata(typeof(T), subject)],
+                arn.Region));
         }
 
         loggerFactory.CreateLogger<TopicPublicationBuilder<T>>().LogInformation(

--- a/src/JustSaying/Fluent/TopicPublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicPublicationBuilder`1.cs
@@ -271,6 +271,12 @@ public sealed class TopicPublicationBuilder<T> : IPublicationBuilder<T> where T 
 
         var client = proxy.GetAwsClientFactory().GetSnsClient(RegionEndpoint.GetBySystemName(region));
 
+        // Resolved once here (rather than inside each built configuration) so the same instance both
+        // serializes messages and describes the publication's wire format in the metadata registry.
+        var serializer = SerializerOverride is null
+            ? bus.MessageBodySerializerFactory.GetSerializer<T>()
+            : SerializerOverride(_serviceResolver);
+
         Func<Exception, object, bool> exceptionHandler =
             ExceptionHandler is null ? null : (ex, message) => ExceptionHandler(ex, (T)message);
         Func<Exception, IReadOnlyCollection<object>, bool> exceptionBatchHandler =
@@ -286,7 +292,7 @@ public sealed class TopicPublicationBuilder<T> : IPublicationBuilder<T> where T 
                 exceptionHandler,
                 exceptionBatchHandler,
                 serviceResolver: _serviceResolver,
-                serializerFactory: SerializerOverride,
+                serializerFactory: (_) => serializer,
                 subjectResolver: SubjectResolver);
 
         var topicName = TopicName ?? _destination.Name;
@@ -315,7 +321,7 @@ public sealed class TopicPublicationBuilder<T> : IPublicationBuilder<T> where T 
                 MessagingDestinationKind.SnsTopic,
                 TopicNameCustomizer != null ? null : bus.Config.TopicNamingConvention.Apply<T>(topicName),
                 isDynamic: TopicNameCustomizer != null,
-                [new MessageTypeMetadata(typeof(T), wireName)]));
+                [new MessageTypeMetadata(typeof(T), wireName, serializer)]));
         }
     }
 
@@ -377,7 +383,7 @@ public sealed class TopicPublicationBuilder<T> : IPublicationBuilder<T> where T 
                 MessagingDestinationKind.SnsTopic,
                 TopicAddressCustomizer != null ? null : arn.Resource,
                 isDynamic: TopicAddressCustomizer != null,
-                [new MessageTypeMetadata(typeof(T), subject)],
+                [new MessageTypeMetadata(typeof(T), subject, serializer)],
                 arn.Region));
         }
 

--- a/src/JustSaying/Fluent/TopicPublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicPublicationBuilder`1.cs
@@ -4,7 +4,9 @@ using JustSaying.AwsTools.MessageHandling;
 using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging;
 using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Metadata;
 using JustSaying.Messaging.Middleware;
+using JustSaying.Naming;
 using Microsoft.Extensions.Logging;
 
 namespace JustSaying.Fluent;
@@ -300,6 +302,21 @@ public sealed class TopicPublicationBuilder<T> : IPublicationBuilder<T> where T 
         bus.AddStartupTask(config.StartupTask);
         bus.AddMessagePublisher<T>(config.Publisher);
         bus.AddMessageBatchPublisher<T>(config.BatchPublisher);
+
+        var metadataRegistry = _serviceResolver.ResolveOptionalService<IMessagingMetadataRegistry>();
+        if (metadataRegistry != null)
+        {
+            var wireName = SubjectSet
+                ? Subject
+                : SubjectResolver?.Invoke(bus.MessageTypeRegistry) ?? bus.MessageTypeRegistry.GetLogicalName(typeof(T));
+
+            metadataRegistry.SetRegion(region);
+            metadataRegistry.AddPublication(new PublicationMetadata(
+                MessagingDestinationKind.SnsTopic,
+                TopicNameCustomizer != null ? null : bus.Config.TopicNamingConvention.Apply<T>(topicName),
+                isDynamic: TopicNameCustomizer != null,
+                [new MessageTypeMetadata(typeof(T), wireName)]));
+        }
     }
 
     private void ConfigureForAddress(JustSayingBus bus, IAwsClientFactoryProxy proxy, ILoggerFactory loggerFactory)
@@ -350,6 +367,17 @@ public sealed class TopicPublicationBuilder<T> : IPublicationBuilder<T> where T 
 
         bus.AddMessagePublisher<T>(publisherConfig.Publisher);
         bus.AddMessageBatchPublisher<T>(publisherConfig.BatchPublisher);
+
+        var metadataRegistry = _serviceResolver.ResolveOptionalService<IMessagingMetadataRegistry>();
+        if (metadataRegistry != null)
+        {
+            metadataRegistry.SetRegion(arn.Region);
+            metadataRegistry.AddPublication(new PublicationMetadata(
+                MessagingDestinationKind.SnsTopic,
+                TopicAddressCustomizer != null ? null : arn.Resource,
+                isDynamic: TopicAddressCustomizer != null,
+                [new MessageTypeMetadata(typeof(T), subject)]));
+        }
 
         loggerFactory.CreateLogger<TopicPublicationBuilder<T>>().LogInformation(
             "Created SNS topic publisher on topic '{TopicName}' for message type '{MessageType}'",

--- a/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
@@ -290,7 +290,7 @@ public sealed class TopicSubscriptionBuilder<T> : ISubscriptionBuilder<T> where 
                 subscriptionConfig.TopicName,
                 subscriptionConfig.SubscriptionGroupName,
                 subscriptionConfig.RawMessageDelivery,
-                [new MessageTypeMetadata(typeof(T), bus.MessageTypeRegistry.GetLogicalName(typeof(T)))]));
+                [new MessageTypeMetadata(typeof(T), bus.MessageTypeRegistry.GetLogicalName(typeof(T)), serializer)]));
         }
 
         logger.LogInformation(

--- a/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
@@ -3,6 +3,7 @@ using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging;
 using JustSaying.Messaging.Channels.SubscriptionGroups;
 using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Metadata;
 using JustSaying.Messaging.Middleware;
 using JustSaying.Models;
 using JustSaying.Naming;
@@ -279,6 +280,18 @@ public sealed class TopicSubscriptionBuilder<T> : ISubscriptionBuilder<T> where 
             .Build();
 
         bus.AddMessageMiddleware<T>(subscriptionConfig.QueueName, handlerMiddleware);
+
+        var metadataRegistry = serviceResolver.ResolveOptionalService<IMessagingMetadataRegistry>();
+        if (metadataRegistry != null)
+        {
+            metadataRegistry.SetRegion(region);
+            metadataRegistry.AddSubscription(new SubscriptionMetadata(
+                subscriptionConfig.QueueName,
+                subscriptionConfig.TopicName,
+                subscriptionConfig.SubscriptionGroupName,
+                subscriptionConfig.RawMessageDelivery,
+                [new MessageTypeMetadata(typeof(T), bus.MessageTypeRegistry.GetLogicalName(typeof(T)))]));
+        }
 
         logger.LogInformation(
             "Added a message handler for message type for '{MessageType}' on topic '{TopicName}' and queue '{QueueName}'.",

--- a/src/JustSaying/Messaging/MessageSerialization/ISystemTextJsonMessageBodySerializer.cs
+++ b/src/JustSaying/Messaging/MessageSerialization/ISystemTextJsonMessageBodySerializer.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+
+namespace JustSaying.Messaging.MessageSerialization;
+
+/// <summary>
+/// Implemented by a message body serializer whose wire format is produced by System.Text.Json, exposing
+/// the <see cref="JsonSerializerOptions"/> it serializes with so that tooling (such as AsyncAPI document
+/// generation) can derive the payload's JSON schema from the same options that shape the wire.
+/// </summary>
+public interface ISystemTextJsonMessageBodySerializer
+{
+    /// <summary>
+    /// Gets the <see cref="JsonSerializerOptions"/> message bodies are serialized with.
+    /// </summary>
+    JsonSerializerOptions SerializerOptions { get; }
+}

--- a/src/JustSaying/Messaging/MessageSerialization/SystemTextJsonMessageBodySerializer`1.cs
+++ b/src/JustSaying/Messaging/MessageSerialization/SystemTextJsonMessageBodySerializer`1.cs
@@ -11,9 +11,12 @@ namespace JustSaying.Messaging.MessageSerialization;
 /// Provides serialization and deserialization functionality for messages of type <typeparamref name="T"/> using System.Text.Json.
 /// </summary>
 /// <typeparam name="T">The type of message to be serialized or deserialized.</typeparam>
-public sealed class SystemTextJsonMessageBodySerializer<T> : IMessageBodySerializer<T> where T : class
+public sealed class SystemTextJsonMessageBodySerializer<T> : IMessageBodySerializer<T>, ISystemTextJsonMessageBodySerializer where T : class
 {
     private readonly JsonSerializerOptions _options;
+
+    /// <inheritdoc />
+    public JsonSerializerOptions SerializerOptions => _options;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SystemTextJsonMessageBodySerializer{T}"/> class with default JSON serializer options.

--- a/src/JustSaying/Messaging/MessageSerialization/SystemTextJsonSerializationFactory.cs
+++ b/src/JustSaying/Messaging/MessageSerialization/SystemTextJsonSerializationFactory.cs
@@ -7,6 +7,12 @@ public sealed class SystemTextJsonSerializationFactory(JsonSerializerOptions opt
 {
     private readonly ConcurrentDictionary<Type, object> _cache = new();
 
+    /// <summary>
+    /// Gets the <see cref="JsonSerializerOptions"/> used by the serializers this factory creates,
+    /// which describe the wire contract of the messages, for example for schema generation.
+    /// </summary>
+    public JsonSerializerOptions SerializerOptions => options;
+
     public IMessageBodySerializer<T> GetSerializer<T>() where T : class
         => (IMessageBodySerializer<T>)_cache.GetOrAdd(typeof(T), _ => new SystemTextJsonMessageBodySerializer<T>(options));
 }

--- a/src/JustSaying/Messaging/Metadata/IMessagingMetadataRegistry.cs
+++ b/src/JustSaying/Messaging/Metadata/IMessagingMetadataRegistry.cs
@@ -1,0 +1,47 @@
+namespace JustSaying.Messaging.Metadata;
+
+/// <summary>
+/// A registry of the publications and subscriptions configured on the messaging bus.
+/// </summary>
+/// <remarks>
+/// The registry is populated by the fluent builders as they are configured, which happens
+/// before the bus is started and before any AWS infrastructure is provisioned. It is only
+/// populated when an implementation is registered with the service resolver, for example
+/// by a documentation package such as AsyncAPI support. Because publisher and subscriber
+/// configuration can each run more than once, implementations must deduplicate entries.
+/// </remarks>
+public interface IMessagingMetadataRegistry
+{
+    /// <summary>
+    /// Gets the AWS region the bus is configured for, or <see langword="null"/> if not yet captured.
+    /// </summary>
+    string Region { get; }
+
+    /// <summary>
+    /// Gets the publications captured by the registry.
+    /// </summary>
+    IReadOnlyCollection<PublicationMetadata> Publications { get; }
+
+    /// <summary>
+    /// Gets the subscriptions captured by the registry.
+    /// </summary>
+    IReadOnlyCollection<SubscriptionMetadata> Subscriptions { get; }
+
+    /// <summary>
+    /// Records the AWS region the bus is configured for.
+    /// </summary>
+    /// <param name="region">The AWS region system name.</param>
+    void SetRegion(string region);
+
+    /// <summary>
+    /// Records a publication.
+    /// </summary>
+    /// <param name="publication">The publication metadata to record.</param>
+    void AddPublication(PublicationMetadata publication);
+
+    /// <summary>
+    /// Records a subscription.
+    /// </summary>
+    /// <param name="subscription">The subscription metadata to record.</param>
+    void AddSubscription(SubscriptionMetadata subscription);
+}

--- a/src/JustSaying/Messaging/Metadata/MessageTypeMetadata.cs
+++ b/src/JustSaying/Messaging/Metadata/MessageTypeMetadata.cs
@@ -10,13 +10,18 @@ public sealed class MessageTypeMetadata
     /// </summary>
     /// <param name="messageType">The CLR type of the message.</param>
     /// <param name="wireName">The logical name used to identify the message on the wire.</param>
+    /// <param name="serializer">
+    /// The <see cref="MessageSerialization.IMessageBodySerializer{TMessage}"/> (for <paramref name="messageType"/>)
+    /// the registration serializes its message bodies with, or <see langword="null"/> when it was not captured.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="messageType"/> is <see langword="null"/>.
     /// </exception>
-    public MessageTypeMetadata(Type messageType, string wireName)
+    public MessageTypeMetadata(Type messageType, string wireName, object serializer = null)
     {
         MessageType = messageType ?? throw new ArgumentNullException(nameof(messageType));
         WireName = wireName;
+        Serializer = serializer;
     }
 
     /// <summary>
@@ -29,4 +34,15 @@ public sealed class MessageTypeMetadata
     /// the message subject or an explicitly registered type name.
     /// </summary>
     public string WireName { get; }
+
+    /// <summary>
+    /// Gets the serializer the registration serializes its message bodies with — an
+    /// <see cref="MessageSerialization.IMessageBodySerializer{TMessage}"/> for <see cref="MessageType"/> —
+    /// or <see langword="null"/> when it was not captured. Serialization is configured per registration
+    /// (a publication or subscription can override the app-wide default), so the serializer is what
+    /// describes the actual wire format of this message: tooling such as AsyncAPI generation inspects it
+    /// (for example for <see cref="MessageSerialization.ISystemTextJsonMessageBodySerializer"/>) to
+    /// derive the payload's content type and schema.
+    /// </summary>
+    public object Serializer { get; }
 }

--- a/src/JustSaying/Messaging/Metadata/MessageTypeMetadata.cs
+++ b/src/JustSaying/Messaging/Metadata/MessageTypeMetadata.cs
@@ -1,0 +1,32 @@
+namespace JustSaying.Messaging.Metadata;
+
+/// <summary>
+/// Describes a message type that flows through a publication or subscription.
+/// </summary>
+public sealed class MessageTypeMetadata
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageTypeMetadata"/> class.
+    /// </summary>
+    /// <param name="messageType">The CLR type of the message.</param>
+    /// <param name="wireName">The logical name used to identify the message on the wire.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="messageType"/> is <see langword="null"/>.
+    /// </exception>
+    public MessageTypeMetadata(Type messageType, string wireName)
+    {
+        MessageType = messageType ?? throw new ArgumentNullException(nameof(messageType));
+        WireName = wireName;
+    }
+
+    /// <summary>
+    /// Gets the CLR type of the message.
+    /// </summary>
+    public Type MessageType { get; }
+
+    /// <summary>
+    /// Gets the logical name used to identify the message on the wire, such as
+    /// the message subject or an explicitly registered type name.
+    /// </summary>
+    public string WireName { get; }
+}

--- a/src/JustSaying/Messaging/Metadata/MessagingDestinationKind.cs
+++ b/src/JustSaying/Messaging/Metadata/MessagingDestinationKind.cs
@@ -1,0 +1,17 @@
+namespace JustSaying.Messaging.Metadata;
+
+/// <summary>
+/// The kind of AWS destination a publication or subscription is bound to.
+/// </summary>
+public enum MessagingDestinationKind
+{
+    /// <summary>
+    /// An SNS topic.
+    /// </summary>
+    SnsTopic,
+
+    /// <summary>
+    /// An SQS queue.
+    /// </summary>
+    SqsQueue,
+}

--- a/src/JustSaying/Messaging/Metadata/MessagingMetadataRegistry.cs
+++ b/src/JustSaying/Messaging/Metadata/MessagingMetadataRegistry.cs
@@ -55,7 +55,7 @@ public sealed class MessagingMetadataRegistry : IMessagingMetadataRegistry
 
         lock (_syncRoot)
         {
-            if (_keys.Add(Key("pub", publication.DestinationKind.ToString(), publication.DestinationName, publication.IsDynamic.ToString(), publication.Messages)))
+            if (_keys.Add(Key("pub", publication.DestinationKind.ToString(), publication.DestinationName, publication.IsDynamic.ToString(), publication.Region, publication.Messages)))
             {
                 _publications.Add(publication);
             }
@@ -69,13 +69,13 @@ public sealed class MessagingMetadataRegistry : IMessagingMetadataRegistry
 
         lock (_syncRoot)
         {
-            if (_keys.Add(Key("sub", subscription.QueueName, subscription.TopicName, subscription.SubscriptionGroupName, subscription.Messages)))
+            if (_keys.Add(Key("sub", subscription.QueueName, subscription.TopicName, subscription.SubscriptionGroupName, subscription.Region, subscription.Messages)))
             {
                 _subscriptions.Add(subscription);
             }
         }
     }
 
-    private static string Key(string direction, string first, string second, string third, IReadOnlyList<MessageTypeMetadata> messages)
-        => string.Join("|", direction, first, second, third, string.Join(",", messages.Select((m) => m.MessageType.AssemblyQualifiedName)));
+    private static string Key(string direction, string first, string second, string third, string region, IReadOnlyList<MessageTypeMetadata> messages)
+        => string.Join("|", direction, first, second, third, region, string.Join(",", messages.Select((m) => m.MessageType.AssemblyQualifiedName)));
 }

--- a/src/JustSaying/Messaging/Metadata/MessagingMetadataRegistry.cs
+++ b/src/JustSaying/Messaging/Metadata/MessagingMetadataRegistry.cs
@@ -1,0 +1,81 @@
+namespace JustSaying.Messaging.Metadata;
+
+/// <summary>
+/// The default <see cref="IMessagingMetadataRegistry"/>. Thread-safe, and deduplicates
+/// entries because publication configuration can run for both the publisher and the
+/// batch publisher.
+/// </summary>
+public sealed class MessagingMetadataRegistry : IMessagingMetadataRegistry
+{
+    private readonly object _syncRoot = new();
+    private readonly List<PublicationMetadata> _publications = [];
+    private readonly List<SubscriptionMetadata> _subscriptions = [];
+    private readonly HashSet<string> _keys = new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public string Region { get; private set; }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<PublicationMetadata> Publications
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return [.. _publications];
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<SubscriptionMetadata> Subscriptions
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return [.. _subscriptions];
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetRegion(string region)
+    {
+        lock (_syncRoot)
+        {
+            Region ??= region;
+        }
+    }
+
+    /// <inheritdoc />
+    public void AddPublication(PublicationMetadata publication)
+    {
+        if (publication == null) throw new ArgumentNullException(nameof(publication));
+
+        lock (_syncRoot)
+        {
+            if (_keys.Add(Key("pub", publication.DestinationKind.ToString(), publication.DestinationName, publication.IsDynamic.ToString(), publication.Messages)))
+            {
+                _publications.Add(publication);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void AddSubscription(SubscriptionMetadata subscription)
+    {
+        if (subscription == null) throw new ArgumentNullException(nameof(subscription));
+
+        lock (_syncRoot)
+        {
+            if (_keys.Add(Key("sub", subscription.QueueName, subscription.TopicName, subscription.SubscriptionGroupName, subscription.Messages)))
+            {
+                _subscriptions.Add(subscription);
+            }
+        }
+    }
+
+    private static string Key(string direction, string first, string second, string third, IReadOnlyList<MessageTypeMetadata> messages)
+        => string.Join("|", direction, first, second, third, string.Join(",", messages.Select((m) => m.MessageType.AssemblyQualifiedName)));
+}

--- a/src/JustSaying/Messaging/Metadata/PublicationMetadata.cs
+++ b/src/JustSaying/Messaging/Metadata/PublicationMetadata.cs
@@ -14,6 +14,7 @@ public sealed class PublicationMetadata
     /// <param name="isDynamic">Whether the destination is computed per-message at publish time.</param>
     /// <param name="messages">The message type(s) published to the destination.</param>
     /// <param name="region">The AWS region of the destination when it was addressed explicitly (for example by ARN), or <see langword="null"/> when the destination is in the bus's configured region.</param>
+    /// <param name="usesQueueEnvelope">Whether messages are wrapped in JustSaying's <c>{ "Message", "Subject" }</c> queue envelope before being sent.</param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="messages"/> is <see langword="null"/>.
     /// </exception>
@@ -22,13 +23,15 @@ public sealed class PublicationMetadata
         string destinationName,
         bool isDynamic,
         IReadOnlyList<MessageTypeMetadata> messages,
-        string region = null)
+        string region = null,
+        bool usesQueueEnvelope = false)
     {
         DestinationKind = destinationKind;
         DestinationName = destinationName;
         IsDynamic = isDynamic;
         Messages = messages ?? throw new ArgumentNullException(nameof(messages));
         Region = string.IsNullOrEmpty(region) ? null : region;
+        UsesQueueEnvelope = usesQueueEnvelope;
     }
 
     /// <summary>
@@ -58,4 +61,12 @@ public sealed class PublicationMetadata
     /// by ARN), or <see langword="null"/> when the destination is in the bus's configured region.
     /// </summary>
     public string Region { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether messages are wrapped in JustSaying's
+    /// <c>{ "Message", "Subject" }</c> queue envelope before being sent, in which case the SQS
+    /// message body is the envelope rather than the message payload itself. Always
+    /// <see langword="false"/> for an SNS topic, which has no such envelope.
+    /// </summary>
+    public bool UsesQueueEnvelope { get; }
 }

--- a/src/JustSaying/Messaging/Metadata/PublicationMetadata.cs
+++ b/src/JustSaying/Messaging/Metadata/PublicationMetadata.cs
@@ -1,0 +1,52 @@
+namespace JustSaying.Messaging.Metadata;
+
+/// <summary>
+/// Describes a publication registered with the messaging bus, captured when the
+/// fluent builders are configured and before any AWS infrastructure is provisioned.
+/// </summary>
+public sealed class PublicationMetadata
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PublicationMetadata"/> class.
+    /// </summary>
+    /// <param name="destinationKind">The kind of destination published to.</param>
+    /// <param name="destinationName">The resolved destination name, or <see langword="null"/> when the destination is dynamic.</param>
+    /// <param name="isDynamic">Whether the destination is computed per-message at publish time.</param>
+    /// <param name="messages">The message type(s) published to the destination.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="messages"/> is <see langword="null"/>.
+    /// </exception>
+    public PublicationMetadata(
+        MessagingDestinationKind destinationKind,
+        string destinationName,
+        bool isDynamic,
+        IReadOnlyList<MessageTypeMetadata> messages)
+    {
+        DestinationKind = destinationKind;
+        DestinationName = destinationName;
+        IsDynamic = isDynamic;
+        Messages = messages ?? throw new ArgumentNullException(nameof(messages));
+    }
+
+    /// <summary>
+    /// Gets the kind of destination published to.
+    /// </summary>
+    public MessagingDestinationKind DestinationKind { get; }
+
+    /// <summary>
+    /// Gets the resolved destination name (topic or queue name), or
+    /// <see langword="null"/> when the destination is dynamic.
+    /// </summary>
+    public string DestinationName { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the destination is computed per-message at
+    /// publish time, for example by a topic name customizer.
+    /// </summary>
+    public bool IsDynamic { get; }
+
+    /// <summary>
+    /// Gets the message type(s) published to the destination.
+    /// </summary>
+    public IReadOnlyList<MessageTypeMetadata> Messages { get; }
+}

--- a/src/JustSaying/Messaging/Metadata/PublicationMetadata.cs
+++ b/src/JustSaying/Messaging/Metadata/PublicationMetadata.cs
@@ -13,6 +13,7 @@ public sealed class PublicationMetadata
     /// <param name="destinationName">The resolved destination name, or <see langword="null"/> when the destination is dynamic.</param>
     /// <param name="isDynamic">Whether the destination is computed per-message at publish time.</param>
     /// <param name="messages">The message type(s) published to the destination.</param>
+    /// <param name="region">The AWS region of the destination when it was addressed explicitly (for example by ARN), or <see langword="null"/> when the destination is in the bus's configured region.</param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="messages"/> is <see langword="null"/>.
     /// </exception>
@@ -20,12 +21,14 @@ public sealed class PublicationMetadata
         MessagingDestinationKind destinationKind,
         string destinationName,
         bool isDynamic,
-        IReadOnlyList<MessageTypeMetadata> messages)
+        IReadOnlyList<MessageTypeMetadata> messages,
+        string region = null)
     {
         DestinationKind = destinationKind;
         DestinationName = destinationName;
         IsDynamic = isDynamic;
         Messages = messages ?? throw new ArgumentNullException(nameof(messages));
+        Region = string.IsNullOrEmpty(region) ? null : region;
     }
 
     /// <summary>
@@ -49,4 +52,10 @@ public sealed class PublicationMetadata
     /// Gets the message type(s) published to the destination.
     /// </summary>
     public IReadOnlyList<MessageTypeMetadata> Messages { get; }
+
+    /// <summary>
+    /// Gets the AWS region of the destination when it was addressed explicitly (for example
+    /// by ARN), or <see langword="null"/> when the destination is in the bus's configured region.
+    /// </summary>
+    public string Region { get; }
 }

--- a/src/JustSaying/Messaging/Metadata/SubscriptionMetadata.cs
+++ b/src/JustSaying/Messaging/Metadata/SubscriptionMetadata.cs
@@ -1,0 +1,59 @@
+namespace JustSaying.Messaging.Metadata;
+
+/// <summary>
+/// Describes a subscription registered with the messaging bus, captured when the
+/// fluent builders are configured and before any AWS infrastructure is provisioned.
+/// </summary>
+public sealed class SubscriptionMetadata
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubscriptionMetadata"/> class.
+    /// </summary>
+    /// <param name="queueName">The resolved name of the queue messages are received from.</param>
+    /// <param name="topicName">The resolved name of the SNS topic the queue is subscribed to, or <see langword="null"/> for point-to-point subscriptions.</param>
+    /// <param name="subscriptionGroupName">The name of the subscription group the queue belongs to.</param>
+    /// <param name="rawMessageDelivery">Whether the subscription uses raw message delivery.</param>
+    /// <param name="messages">The message type(s) handled from the queue.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="queueName"/> or <paramref name="messages"/> is <see langword="null"/>.
+    /// </exception>
+    public SubscriptionMetadata(
+        string queueName,
+        string topicName,
+        string subscriptionGroupName,
+        bool rawMessageDelivery,
+        IReadOnlyList<MessageTypeMetadata> messages)
+    {
+        QueueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
+        TopicName = topicName;
+        SubscriptionGroupName = subscriptionGroupName;
+        RawMessageDelivery = rawMessageDelivery;
+        Messages = messages ?? throw new ArgumentNullException(nameof(messages));
+    }
+
+    /// <summary>
+    /// Gets the resolved name of the queue messages are received from.
+    /// </summary>
+    public string QueueName { get; }
+
+    /// <summary>
+    /// Gets the resolved name of the SNS topic the queue is subscribed to, or
+    /// <see langword="null"/> for point-to-point subscriptions.
+    /// </summary>
+    public string TopicName { get; }
+
+    /// <summary>
+    /// Gets the name of the subscription group the queue belongs to.
+    /// </summary>
+    public string SubscriptionGroupName { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the subscription uses raw message delivery.
+    /// </summary>
+    public bool RawMessageDelivery { get; }
+
+    /// <summary>
+    /// Gets the message type(s) handled from the queue.
+    /// </summary>
+    public IReadOnlyList<MessageTypeMetadata> Messages { get; }
+}

--- a/src/JustSaying/Messaging/Metadata/SubscriptionMetadata.cs
+++ b/src/JustSaying/Messaging/Metadata/SubscriptionMetadata.cs
@@ -14,6 +14,7 @@ public sealed class SubscriptionMetadata
     /// <param name="subscriptionGroupName">The name of the subscription group the queue belongs to.</param>
     /// <param name="rawMessageDelivery">Whether the subscription uses raw message delivery.</param>
     /// <param name="messages">The message type(s) handled from the queue.</param>
+    /// <param name="region">The AWS region of the queue when it was addressed explicitly (for example by ARN or URL), or <see langword="null"/> when the queue is in the bus's configured region.</param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="queueName"/> or <paramref name="messages"/> is <see langword="null"/>.
     /// </exception>
@@ -22,13 +23,15 @@ public sealed class SubscriptionMetadata
         string topicName,
         string subscriptionGroupName,
         bool rawMessageDelivery,
-        IReadOnlyList<MessageTypeMetadata> messages)
+        IReadOnlyList<MessageTypeMetadata> messages,
+        string region = null)
     {
         QueueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
         TopicName = topicName;
         SubscriptionGroupName = subscriptionGroupName;
         RawMessageDelivery = rawMessageDelivery;
         Messages = messages ?? throw new ArgumentNullException(nameof(messages));
+        Region = string.IsNullOrEmpty(region) ? null : region;
     }
 
     /// <summary>
@@ -56,4 +59,10 @@ public sealed class SubscriptionMetadata
     /// Gets the message type(s) handled from the queue.
     /// </summary>
     public IReadOnlyList<MessageTypeMetadata> Messages { get; }
+
+    /// <summary>
+    /// Gets the AWS region of the queue when it was addressed explicitly (for example by
+    /// ARN or URL), or <see langword="null"/> when the queue is in the bus's configured region.
+    /// </summary>
+    public string Region { get; }
 }

--- a/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
@@ -432,12 +432,14 @@ JustSaying.Messaging.Metadata.PublicationMetadata.DestinationKind.get -> JustSay
 JustSaying.Messaging.Metadata.PublicationMetadata.DestinationName.get -> string
 JustSaying.Messaging.Metadata.PublicationMetadata.IsDynamic.get -> bool
 JustSaying.Messaging.Metadata.PublicationMetadata.Messages.get -> System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata>
-JustSaying.Messaging.Metadata.PublicationMetadata.PublicationMetadata(JustSaying.Messaging.Metadata.MessagingDestinationKind destinationKind, string destinationName, bool isDynamic, System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata> messages) -> void
+JustSaying.Messaging.Metadata.PublicationMetadata.PublicationMetadata(JustSaying.Messaging.Metadata.MessagingDestinationKind destinationKind, string destinationName, bool isDynamic, System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata> messages, string region = null) -> void
+JustSaying.Messaging.Metadata.PublicationMetadata.Region.get -> string
 JustSaying.Messaging.Metadata.SubscriptionMetadata
 JustSaying.Messaging.Metadata.SubscriptionMetadata.Messages.get -> System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata>
 JustSaying.Messaging.Metadata.SubscriptionMetadata.QueueName.get -> string
 JustSaying.Messaging.Metadata.SubscriptionMetadata.RawMessageDelivery.get -> bool
 JustSaying.Messaging.Metadata.SubscriptionMetadata.SubscriptionGroupName.get -> string
-JustSaying.Messaging.Metadata.SubscriptionMetadata.SubscriptionMetadata(string queueName, string topicName, string subscriptionGroupName, bool rawMessageDelivery, System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata> messages) -> void
+JustSaying.Messaging.Metadata.SubscriptionMetadata.SubscriptionMetadata(string queueName, string topicName, string subscriptionGroupName, bool rawMessageDelivery, System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata> messages, string region = null) -> void
+JustSaying.Messaging.Metadata.SubscriptionMetadata.Region.get -> string
 JustSaying.Messaging.Metadata.SubscriptionMetadata.TopicName.get -> string
 JustSaying.Messaging.MessageSerialization.SystemTextJsonSerializationFactory.SerializerOptions.get -> System.Text.Json.JsonSerializerOptions

--- a/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
@@ -432,8 +432,9 @@ JustSaying.Messaging.Metadata.PublicationMetadata.DestinationKind.get -> JustSay
 JustSaying.Messaging.Metadata.PublicationMetadata.DestinationName.get -> string
 JustSaying.Messaging.Metadata.PublicationMetadata.IsDynamic.get -> bool
 JustSaying.Messaging.Metadata.PublicationMetadata.Messages.get -> System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata>
-JustSaying.Messaging.Metadata.PublicationMetadata.PublicationMetadata(JustSaying.Messaging.Metadata.MessagingDestinationKind destinationKind, string destinationName, bool isDynamic, System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata> messages, string region = null) -> void
+JustSaying.Messaging.Metadata.PublicationMetadata.PublicationMetadata(JustSaying.Messaging.Metadata.MessagingDestinationKind destinationKind, string destinationName, bool isDynamic, System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata> messages, string region = null, bool usesQueueEnvelope = false) -> void
 JustSaying.Messaging.Metadata.PublicationMetadata.Region.get -> string
+JustSaying.Messaging.Metadata.PublicationMetadata.UsesQueueEnvelope.get -> bool
 JustSaying.Messaging.Metadata.SubscriptionMetadata
 JustSaying.Messaging.Metadata.SubscriptionMetadata.Messages.get -> System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata>
 JustSaying.Messaging.Metadata.SubscriptionMetadata.QueueName.get -> string

--- a/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
@@ -413,8 +413,9 @@ JustSaying.Messaging.Metadata.IMessagingMetadataRegistry.Region.get -> string
 JustSaying.Messaging.Metadata.IMessagingMetadataRegistry.SetRegion(string region) -> void
 JustSaying.Messaging.Metadata.IMessagingMetadataRegistry.Subscriptions.get -> System.Collections.Generic.IReadOnlyCollection<JustSaying.Messaging.Metadata.SubscriptionMetadata>
 JustSaying.Messaging.Metadata.MessageTypeMetadata
-JustSaying.Messaging.Metadata.MessageTypeMetadata.MessageTypeMetadata(System.Type messageType, string wireName) -> void
+JustSaying.Messaging.Metadata.MessageTypeMetadata.MessageTypeMetadata(System.Type messageType, string wireName, object serializer = null) -> void
 JustSaying.Messaging.Metadata.MessageTypeMetadata.MessageType.get -> System.Type
+JustSaying.Messaging.Metadata.MessageTypeMetadata.Serializer.get -> object
 JustSaying.Messaging.Metadata.MessageTypeMetadata.WireName.get -> string
 JustSaying.Messaging.Metadata.MessagingDestinationKind
 JustSaying.Messaging.Metadata.MessagingDestinationKind.SnsTopic = 0 -> JustSaying.Messaging.Metadata.MessagingDestinationKind
@@ -444,3 +445,6 @@ JustSaying.Messaging.Metadata.SubscriptionMetadata.SubscriptionMetadata(string q
 JustSaying.Messaging.Metadata.SubscriptionMetadata.Region.get -> string
 JustSaying.Messaging.Metadata.SubscriptionMetadata.TopicName.get -> string
 JustSaying.Messaging.MessageSerialization.SystemTextJsonSerializationFactory.SerializerOptions.get -> System.Text.Json.JsonSerializerOptions
+JustSaying.Messaging.MessageSerialization.ISystemTextJsonMessageBodySerializer
+JustSaying.Messaging.MessageSerialization.ISystemTextJsonMessageBodySerializer.SerializerOptions.get -> System.Text.Json.JsonSerializerOptions
+JustSaying.Messaging.MessageSerialization.SystemTextJsonMessageBodySerializer<T>.SerializerOptions.get -> System.Text.Json.JsonSerializerOptions

--- a/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
@@ -405,3 +405,39 @@ JustSaying.Messaging.Middleware.Logging.LoggingMiddleware.LoggingMiddleware(Micr
 *REMOVED*static JustSaying.Messaging.MessagePublisherExtensions.PublishAsync(this JustSaying.Messaging.IMessagePublisher publisher, System.Collections.Generic.IEnumerable<JustSaying.Models.Message> messages, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 *REMOVED*static JustSaying.Messaging.MessagePublisherExtensions.PublishAsync(this JustSaying.Messaging.IMessagePublisher publisher, System.Collections.Generic.IEnumerable<JustSaying.Models.Message> messages) -> System.Threading.Tasks.Task
 *REMOVED*static JustSaying.Messaging.Middleware.ExactlyOnceHandlerMiddlewareBuilderExtensions.UseExactlyOnce<TMessage>(this JustSaying.Messaging.Middleware.HandlerMiddlewareBuilder builder, string lockKey, System.TimeSpan? lockDuration = null) -> JustSaying.Messaging.Middleware.HandlerMiddlewareBuilder
+JustSaying.Messaging.Metadata.IMessagingMetadataRegistry
+JustSaying.Messaging.Metadata.IMessagingMetadataRegistry.AddPublication(JustSaying.Messaging.Metadata.PublicationMetadata publication) -> void
+JustSaying.Messaging.Metadata.IMessagingMetadataRegistry.AddSubscription(JustSaying.Messaging.Metadata.SubscriptionMetadata subscription) -> void
+JustSaying.Messaging.Metadata.IMessagingMetadataRegistry.Publications.get -> System.Collections.Generic.IReadOnlyCollection<JustSaying.Messaging.Metadata.PublicationMetadata>
+JustSaying.Messaging.Metadata.IMessagingMetadataRegistry.Region.get -> string
+JustSaying.Messaging.Metadata.IMessagingMetadataRegistry.SetRegion(string region) -> void
+JustSaying.Messaging.Metadata.IMessagingMetadataRegistry.Subscriptions.get -> System.Collections.Generic.IReadOnlyCollection<JustSaying.Messaging.Metadata.SubscriptionMetadata>
+JustSaying.Messaging.Metadata.MessageTypeMetadata
+JustSaying.Messaging.Metadata.MessageTypeMetadata.MessageTypeMetadata(System.Type messageType, string wireName) -> void
+JustSaying.Messaging.Metadata.MessageTypeMetadata.MessageType.get -> System.Type
+JustSaying.Messaging.Metadata.MessageTypeMetadata.WireName.get -> string
+JustSaying.Messaging.Metadata.MessagingDestinationKind
+JustSaying.Messaging.Metadata.MessagingDestinationKind.SnsTopic = 0 -> JustSaying.Messaging.Metadata.MessagingDestinationKind
+JustSaying.Messaging.Metadata.MessagingDestinationKind.SqsQueue = 1 -> JustSaying.Messaging.Metadata.MessagingDestinationKind
+JustSaying.Messaging.Metadata.MessagingMetadataRegistry
+JustSaying.Messaging.Metadata.MessagingMetadataRegistry.AddPublication(JustSaying.Messaging.Metadata.PublicationMetadata publication) -> void
+JustSaying.Messaging.Metadata.MessagingMetadataRegistry.AddSubscription(JustSaying.Messaging.Metadata.SubscriptionMetadata subscription) -> void
+JustSaying.Messaging.Metadata.MessagingMetadataRegistry.MessagingMetadataRegistry() -> void
+JustSaying.Messaging.Metadata.MessagingMetadataRegistry.Publications.get -> System.Collections.Generic.IReadOnlyCollection<JustSaying.Messaging.Metadata.PublicationMetadata>
+JustSaying.Messaging.Metadata.MessagingMetadataRegistry.Region.get -> string
+JustSaying.Messaging.Metadata.MessagingMetadataRegistry.SetRegion(string region) -> void
+JustSaying.Messaging.Metadata.MessagingMetadataRegistry.Subscriptions.get -> System.Collections.Generic.IReadOnlyCollection<JustSaying.Messaging.Metadata.SubscriptionMetadata>
+JustSaying.Messaging.Metadata.PublicationMetadata
+JustSaying.Messaging.Metadata.PublicationMetadata.DestinationKind.get -> JustSaying.Messaging.Metadata.MessagingDestinationKind
+JustSaying.Messaging.Metadata.PublicationMetadata.DestinationName.get -> string
+JustSaying.Messaging.Metadata.PublicationMetadata.IsDynamic.get -> bool
+JustSaying.Messaging.Metadata.PublicationMetadata.Messages.get -> System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata>
+JustSaying.Messaging.Metadata.PublicationMetadata.PublicationMetadata(JustSaying.Messaging.Metadata.MessagingDestinationKind destinationKind, string destinationName, bool isDynamic, System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata> messages) -> void
+JustSaying.Messaging.Metadata.SubscriptionMetadata
+JustSaying.Messaging.Metadata.SubscriptionMetadata.Messages.get -> System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata>
+JustSaying.Messaging.Metadata.SubscriptionMetadata.QueueName.get -> string
+JustSaying.Messaging.Metadata.SubscriptionMetadata.RawMessageDelivery.get -> bool
+JustSaying.Messaging.Metadata.SubscriptionMetadata.SubscriptionGroupName.get -> string
+JustSaying.Messaging.Metadata.SubscriptionMetadata.SubscriptionMetadata(string queueName, string topicName, string subscriptionGroupName, bool rawMessageDelivery, System.Collections.Generic.IReadOnlyList<JustSaying.Messaging.Metadata.MessageTypeMetadata> messages) -> void
+JustSaying.Messaging.Metadata.SubscriptionMetadata.TopicName.get -> string
+JustSaying.Messaging.MessageSerialization.SystemTextJsonSerializationFactory.SerializerOptions.get -> System.Text.Json.JsonSerializerOptions

--- a/tests/JustSaying.AsyncApi.Tests.App/JustSaying.AsyncApi.Tests.App.csproj
+++ b/tests/JustSaying.AsyncApi.Tests.App/JustSaying.AsyncApi.Tests.App.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    A minimal JustSaying application used by JustSaying.AsyncApi.Tests to exercise the
+    JustSaying.AsyncApi.GetDocument tool the way the JustSaying.AsyncApi.BuildTools MSBuild
+    targets invoke it. Environment variables (see Program.cs) put the app into the failure
+    modes the tool reports build errors for.
+  -->
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>JustSaying.AsyncApi.Tests.App</RootNamespace>
+    <SignAssembly>false</SignAssembly>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\JustSaying\JustSaying.csproj" />
+    <ProjectReference Include="..\..\src\JustSaying.AsyncApi\JustSaying.AsyncApi.csproj" />
+    <ProjectReference Include="..\..\src\JustSaying.Extensions.DependencyInjection.Microsoft\JustSaying.Extensions.DependencyInjection.Microsoft.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+</Project>

--- a/tests/JustSaying.AsyncApi.Tests.App/Program.cs
+++ b/tests/JustSaying.AsyncApi.Tests.App/Program.cs
@@ -5,6 +5,13 @@ using JustSaying.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
+if (Environment.GetEnvironmentVariable("JUSTSAYING_TESTAPP_BLOCK_STARTUP") == "1")
+{
+    // Simulates an application that does slow work before building its host, to exercise the
+    // generation tool's entry point timeout.
+    Thread.Sleep(TimeSpan.FromMinutes(4));
+}
+
 var builder = Host.CreateApplicationBuilder(args);
 
 builder.Services.AddJustSaying(config =>

--- a/tests/JustSaying.AsyncApi.Tests.App/Program.cs
+++ b/tests/JustSaying.AsyncApi.Tests.App/Program.cs
@@ -1,0 +1,49 @@
+using JustSaying;
+using JustSaying.AsyncApi.Tests.App;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddJustSaying(config =>
+{
+    config.Messaging(x => x.WithRegion("eu-west-1"));
+    config.Publications(x => x.WithTopic<OrderReadyEvent>());
+    config.Subscriptions(x => x.ForTopic<OrderPlacedEvent>());
+});
+
+if (Environment.GetEnvironmentVariable("JUSTSAYING_TESTAPP_SKIP_HANDLER") != "1")
+{
+    builder.Services.AddJustSayingHandler<OrderPlacedEvent, OrderPlacedEventHandler>();
+}
+
+if (Environment.GetEnvironmentVariable("JUSTSAYING_TESTAPP_SKIP_ASYNCAPI") != "1")
+{
+    builder.Services.AddJustSayingAsyncApi(options => options.Title = "Test App");
+}
+
+var host = builder.Build();
+
+// The document generation tool aborts the host inside Build(), so nothing below runs during
+// build-time generation. Running the app directly just exits without starting the bus.
+_ = host;
+
+namespace JustSaying.AsyncApi.Tests.App
+{
+    public class OrderPlacedEvent : Message
+    {
+        public int OrderId { get; set; }
+    }
+
+    public class OrderReadyEvent : Message
+    {
+        public int OrderId { get; set; }
+    }
+
+    public class OrderPlacedEventHandler : IHandlerAsync<OrderPlacedEvent>
+    {
+        public Task<bool> Handle(OrderPlacedEvent message) => Task.FromResult(true);
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/JustSaying.AsyncApi.Tests.csproj
+++ b/tests/JustSaying.AsyncApi.Tests/JustSaying.AsyncApi.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <NoWarn>$(NoWarn);CA1707;CA2007</NoWarn>
+    <RootNamespace>JustSaying.AsyncApi.Tests</RootNamespace>
+    <SignAssembly>false</SignAssembly>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\JustSaying.AsyncApi\JustSaying.AsyncApi.csproj" />
+    <ProjectReference Include="..\..\src\JustSaying.CloudEvents\JustSaying.CloudEvents.csproj" />
+    <ProjectReference Include="..\..\src\JustSaying\JustSaying.csproj" />
+    <ProjectReference Include="..\..\src\JustSaying.Extensions.DependencyInjection.Microsoft\JustSaying.Extensions.DependencyInjection.Microsoft.csproj" />
+    <ProjectReference Include="..\..\tests\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+</Project>

--- a/tests/JustSaying.AsyncApi.Tests/JustSaying.AsyncApi.Tests.csproj
+++ b/tests/JustSaying.AsyncApi.Tests/JustSaying.AsyncApi.Tests.csproj
@@ -13,6 +13,20 @@
     <ProjectReference Include="..\..\src\JustSaying.Extensions.DependencyInjection.Microsoft\JustSaying.Extensions.DependencyInjection.Microsoft.csproj" />
     <ProjectReference Include="..\..\tests\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
+  <!--
+    The build-time generation tests spawn the JustSaying.AsyncApi.GetDocument tool against the
+    JustSaying.AsyncApi.Tests.App application, so both must be built (but are not referenced as
+    assemblies), and the tests find their outputs via the assembly metadata below.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\JustSaying.AsyncApi.BuildTools\JustSaying.AsyncApi.BuildTools.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\JustSaying.AsyncApi.Tests.App\JustSaying.AsyncApi.Tests.App.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Projects under tests/ and src/ have different artifacts roots (each tree has its own Directory.Build.props). -->
+    <AssemblyMetadata Include="TestAppDirectory" Value="$([MSBuild]::NormalizeDirectory('$(ArtifactsPath)', 'bin', 'JustSaying.AsyncApi.Tests.App', '$(Configuration.ToLowerInvariant())'))" />
+    <AssemblyMetadata Include="GetDocumentToolPath" Value="$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', '..', 'artifacts', 'bin', 'JustSaying.AsyncApi.BuildTools', '$(Configuration.ToLowerInvariant())', 'JustSaying.AsyncApi.GetDocument.dll'))" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="TUnit" />

--- a/tests/JustSaying.AsyncApi.Tests/MessagingMetadataRegistryTests.cs
+++ b/tests/JustSaying.AsyncApi.Tests/MessagingMetadataRegistryTests.cs
@@ -1,0 +1,43 @@
+using JustSaying.Messaging.Metadata;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class MessagingMetadataRegistryTests
+{
+    private sealed class OrderPlaced;
+
+    [Test]
+    public async Task DuplicatePublicationsAreRecordedOnce()
+    {
+        var registry = new MessagingMetadataRegistry();
+        var messages = new[] { new MessageTypeMetadata(typeof(OrderPlaced), "orderplaced") };
+
+        // Publication configuration runs for both the publisher and the batch publisher.
+        registry.AddPublication(new PublicationMetadata(MessagingDestinationKind.SnsTopic, "orderplaced", false, messages));
+        registry.AddPublication(new PublicationMetadata(MessagingDestinationKind.SnsTopic, "orderplaced", false, messages));
+
+        await Assert.That(registry.Publications.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task DuplicateSubscriptionsAreRecordedOnce()
+    {
+        var registry = new MessagingMetadataRegistry();
+        var messages = new[] { new MessageTypeMetadata(typeof(OrderPlaced), "orderplaced") };
+
+        registry.AddSubscription(new SubscriptionMetadata("orders", "orderplaced", "orders", false, messages));
+        registry.AddSubscription(new SubscriptionMetadata("orders", "orderplaced", "orders", false, messages));
+
+        await Assert.That(registry.Subscriptions.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TheFirstRegionWins()
+    {
+        var registry = new MessagingMetadataRegistry();
+        registry.SetRegion("eu-west-1");
+        registry.SetRegion("us-east-1");
+
+        await Assert.That(registry.Region).IsEqualTo("eu-west-1");
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenAChannelNameAndSchemaAreShared.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenAChannelNameAndSchemaAreShared.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using JustSaying.AwsTools;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.TestingFramework;
+using LocalSqsSnsMessaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenAChannelNameAndSchemaAreShared
+{
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    public sealed class Category
+    {
+        public string Name { get; set; }
+        public Category Parent { get; set; }
+    }
+
+    public sealed class OrderPlacedHandler : IHandlerAsync<OrderPlaced>
+    {
+        public Task<bool> Handle(OrderPlaced message) => Task.FromResult(true);
+    }
+
+    private static async Task<JsonDocument> GenerateAsync(IServiceProvider serviceProvider)
+    {
+        var provider = serviceProvider.GetRequiredService<IAsyncApiDocumentProvider>();
+        using var writer = new StringWriter();
+        await provider.GenerateAsync(provider.GetDocumentNames()[0], writer);
+        return JsonDocument.Parse(writer.ToString());
+    }
+
+    [Test]
+    public async Task ATopicAndQueueThatShareANameBecomeDistinctChannels()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IAwsClientFactory>(new LocalAwsClientFactory(new InMemoryAwsBus()));
+        services.AddJustSaying((config) =>
+        {
+            config.Messaging((x) => x.WithRegion("eu-west-1"));
+
+            // Publishing and subscribing the same message type: the topic and the queue both
+            // default to the message type name, so their channels must not collapse into one.
+            config.Publications((x) => x.WithTopic<OrderPlaced>());
+            config.Subscriptions((x) => x.ForTopic<OrderPlaced>());
+        });
+        services.AddJustSayingHandler<OrderPlaced, OrderPlacedHandler>();
+        services.AddJustSayingAsyncApi();
+
+        using var document = await GenerateAsync(services.BuildServiceProvider());
+        var root = document.RootElement;
+
+        var channels = root.GetProperty("channels");
+        var topicChannel = channels.GetProperty("orderplaced");
+        var queueChannel = channels.GetProperty("orderplaced-queue");
+
+        await Assert.That(topicChannel.GetProperty("address").GetString()).IsEqualTo("orderplaced");
+        await Assert.That(queueChannel.GetProperty("address").GetString()).IsEqualTo("orderplaced");
+
+        // The topic channel is served by SNS and the queue channel by SQS.
+        await Assert.That(topicChannel.GetProperty("servers")[0].GetProperty("$ref").GetString()).IsEqualTo("#/servers/sns");
+        await Assert.That(queueChannel.GetProperty("servers")[0].GetProperty("$ref").GetString()).IsEqualTo("#/servers/sqs");
+
+        var operations = root.GetProperty("operations");
+        await Assert.That(operations.GetProperty("send-orderplaced").GetProperty("channel").GetProperty("$ref").GetString()).IsEqualTo("#/channels/orderplaced");
+        await Assert.That(operations.GetProperty("receive-orderplaced-queue").GetProperty("channel").GetProperty("$ref").GetString()).IsEqualTo("#/channels/orderplaced-queue");
+    }
+
+    [Test]
+    public async Task ARecursiveMessageTypeIsInlinedRatherThanDropped()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IAwsClientFactory>(new LocalAwsClientFactory(new InMemoryAwsBus()));
+        services.AddJustSaying((config) =>
+        {
+            config.Messaging((x) => x.WithRegion("eu-west-1"));
+            config.Publications((x) => x.WithTopic<Category>());
+        });
+        services.AddJustSayingAsyncApi();
+
+        using var document = await GenerateAsync(services.BuildServiceProvider());
+        var root = document.RootElement;
+
+        var payload = root.GetProperty("channels").GetProperty("category").GetProperty("messages").EnumerateObject().First().Value.GetProperty("payload");
+
+        // The self-referential Parent is inlined one level deep instead of being dropped as an
+        // empty schema: the nested Parent still carries its own properties.
+        var parent = payload.GetProperty("properties").GetProperty("Parent");
+        await Assert.That(parent.TryGetProperty("properties", out var parentProperties)).IsTrue();
+        await Assert.That(parentProperties.GetProperty("Parent").TryGetProperty("properties", out var nestedProperties)).IsTrue();
+        await Assert.That(nestedProperties.TryGetProperty("Name", out _)).IsTrue();
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenAHandlerIsNotRegistered.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenAHandlerIsNotRegistered.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenAHandlerIsNotRegistered
+{
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    [Test]
+    public async Task TheErrorExplainsThatDocumentGenerationBuildsTheBus()
+    {
+        // Building the bus resolves every subscription's handler eagerly, so a missing handler
+        // fails document generation. The surprise of a docs call requiring handlers is
+        // softened by an error that says what happened and what to register.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddJustSaying((config) =>
+        {
+            config.Messaging((x) => x.WithRegion("eu-west-1"));
+            config.Subscriptions((x) => x.ForTopic<OrderPlaced>());
+        });
+        services.AddJustSayingAsyncApi();
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IAsyncApiDocumentProvider>();
+        using var writer = new StringWriter();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => provider.GenerateAsync(provider.GetDocumentNames()[0], writer));
+
+        await Assert.That(exception.Message).Contains("builds the JustSaying messaging bus");
+        await Assert.That(exception.Message).Contains("AddJustSayingHandler");
+        await Assert.That(exception.InnerException).IsNotNull();
+        await Assert.That(exception.InnerException!.Message).Contains(nameof(OrderPlaced));
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenAMessageTypeIsGeneric.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenAMessageTypeIsGeneric.cs
@@ -1,0 +1,39 @@
+using JustSaying.Messaging.Metadata;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenAMessageTypeIsGeneric
+{
+    public sealed class OrderReady
+    {
+        public string OrderId { get; set; }
+    }
+
+    public sealed class Envelope<T>
+    {
+        public T Body { get; set; }
+    }
+
+    [Test]
+    public async Task TheTitleAndSummaryExpandTheGenericArguments()
+    {
+        var registry = new MessagingMetadataRegistry();
+        registry.SetRegion("eu-west-1");
+        registry.AddPublication(new PublicationMetadata(
+            MessagingDestinationKind.SnsTopic,
+            "envelopeorderready",
+            isDynamic: false,
+            [new MessageTypeMetadata(typeof(Envelope<OrderReady>), typeof(Envelope<OrderReady>).Name)]));
+
+        var generator = new AsyncApiDocumentGenerator(registry, new AsyncApiOptions());
+        var document = generator.Generate();
+
+        var message = document.Channels["envelopeorderready"].Messages.Single().Value;
+
+        // The title is for humans, so the closed generic is expanded; the name stays faithful
+        // to the wire discriminator, which is the registered logical name (Type.Name here).
+        await Assert.That(message.Title).IsEqualTo("Envelope<OrderReady>");
+        await Assert.That(message.Name).IsEqualTo("Envelope`1");
+        await Assert.That(document.Operations["send-envelopeorderready"].Summary).Contains("Envelope<OrderReady>");
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenDestinationsAreSharedOrCrossRegion.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenDestinationsAreSharedOrCrossRegion.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using JustSaying.AwsTools;
+using JustSaying.TestingFramework;
+using LocalSqsSnsMessaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenDestinationsAreSharedOrCrossRegion
+{
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    public sealed class OrderReady
+    {
+        public string OrderId { get; set; }
+    }
+
+    private static async Task<JsonDocument> GenerateAsync(IServiceProvider serviceProvider)
+    {
+        var provider = serviceProvider.GetRequiredService<IAsyncApiDocumentProvider>();
+        using var writer = new StringWriter();
+        await provider.GenerateAsync(provider.GetDocumentNames()[0], writer);
+        return JsonDocument.Parse(writer.ToString());
+    }
+
+    [Test]
+    public async Task PublicationsToTheSameTopicMergeIntoOneSendOperation()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IAwsClientFactory>(new LocalAwsClientFactory(new InMemoryAwsBus()));
+        services.AddJustSaying((config) =>
+        {
+            config.Messaging((x) => x.WithRegion("eu-west-1"));
+            config.Publications((x) =>
+            {
+                x.WithTopic<OrderPlaced>((c) => c.WithTopicName("orders"));
+                x.WithTopic<OrderReady>((c) => c.WithTopicName("orders"));
+            });
+        });
+        services.AddJustSayingAsyncApi();
+
+        using var document = await GenerateAsync(services.BuildServiceProvider());
+        var root = document.RootElement;
+
+        var channelMessages = root.GetProperty("channels").GetProperty("orders").GetProperty("messages");
+        await Assert.That(channelMessages.TryGetProperty("OrderPlaced", out _)).IsTrue();
+        await Assert.That(channelMessages.TryGetProperty("OrderReady", out _)).IsTrue();
+
+        // The second publication must not overwrite the first's message references.
+        var operation = root.GetProperty("operations").GetProperty("send-orders");
+        var references = operation.GetProperty("messages").EnumerateArray().Select((m) => m.GetProperty("$ref").GetString()).ToList();
+        await Assert.That(references).Contains("#/channels/orders/messages/OrderPlaced");
+        await Assert.That(references).Contains("#/channels/orders/messages/OrderReady");
+    }
+
+    [Test]
+    public async Task ACrossRegionTopicGetsItsOwnServer()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IAwsClientFactory>(new LocalAwsClientFactory(new InMemoryAwsBus()));
+        services.AddJustSaying((config) =>
+        {
+            config.Messaging((x) => x.WithRegion("eu-west-1"));
+            config.Publications((x) =>
+            {
+                x.WithTopic<OrderPlaced>();
+                x.WithTopicArn<OrderReady>("arn:aws:sns:us-east-1:123456789012:external-orders");
+            });
+        });
+        services.AddJustSayingAsyncApi();
+
+        using var document = await GenerateAsync(services.BuildServiceProvider());
+        var root = document.RootElement;
+
+        // The bus's own region keeps the plain server key; the cross-region topic must not
+        // be documented against it.
+        var servers = root.GetProperty("servers");
+        await Assert.That(servers.GetProperty("sns").GetProperty("host").GetString()).IsEqualTo("sns.eu-west-1.amazonaws.com");
+        await Assert.That(servers.GetProperty("sns-us-east-1").GetProperty("host").GetString()).IsEqualTo("sns.us-east-1.amazonaws.com");
+
+        var channels = root.GetProperty("channels");
+        await Assert.That(channels.GetProperty("orderplaced").GetProperty("servers")[0].GetProperty("$ref").GetString()).IsEqualTo("#/servers/sns");
+        await Assert.That(channels.GetProperty("external-orders").GetProperty("servers")[0].GetProperty("$ref").GetString()).IsEqualTo("#/servers/sns-us-east-1");
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenDocumentingSnsDeliveryMode.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenDocumentingSnsDeliveryMode.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using JustSaying.AwsTools;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.TestingFramework;
+using LocalSqsSnsMessaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenDocumentingSnsDeliveryMode
+{
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    public sealed class OrderDispatched
+    {
+        public string OrderId { get; set; }
+    }
+
+    public sealed class OrderPlacedHandler : IHandlerAsync<OrderPlaced>
+    {
+        public Task<bool> Handle(OrderPlaced message) => Task.FromResult(true);
+    }
+
+    public sealed class OrderDispatchedHandler : IHandlerAsync<OrderDispatched>
+    {
+        public Task<bool> Handle(OrderDispatched message) => Task.FromResult(true);
+    }
+
+    private static async Task<JsonDocument> GenerateAsync(bool rawMessageDelivery)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IAwsClientFactory>(new LocalAwsClientFactory(new InMemoryAwsBus()));
+        services.AddJustSaying((config) =>
+        {
+            config.Messaging((x) => x.WithRegion("eu-west-1"));
+            config.Subscriptions((x) =>
+            {
+                x.ForTopic<OrderPlaced>((topic) =>
+                {
+                    if (rawMessageDelivery)
+                    {
+                        topic.WithRawMessageDelivery();
+                    }
+                });
+                x.ForQueue<OrderDispatched>();
+            });
+        });
+        services.AddJustSayingHandler<OrderPlaced, OrderPlacedHandler>();
+        services.AddJustSayingHandler<OrderDispatched, OrderDispatchedHandler>();
+        services.AddJustSayingAsyncApi();
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IAsyncApiDocumentProvider>();
+        using var writer = new StringWriter();
+        await provider.GenerateAsync(provider.GetDocumentNames()[0], writer);
+        return JsonDocument.Parse(writer.ToString());
+    }
+
+    [Test]
+    public async Task AClassicTopicSubscriptionDescribesTheSnsNotificationEnvelope()
+    {
+        using var document = await GenerateAsync(rawMessageDelivery: false);
+        var root = document.RootElement;
+
+        var operation = root.GetProperty("operations").GetProperty("receive-orderplaced");
+        var description = operation.GetProperty("description").GetString();
+        await Assert.That(description).Contains("does not use raw message delivery");
+        await Assert.That(description).Contains("Amazon SNS notification envelope");
+    }
+
+    [Test]
+    public async Task ARawTopicSubscriptionDescribesRawMessageDelivery()
+    {
+        using var document = await GenerateAsync(rawMessageDelivery: true);
+        var root = document.RootElement;
+
+        var operation = root.GetProperty("operations").GetProperty("receive-orderplaced");
+        var description = operation.GetProperty("description").GetString();
+        await Assert.That(description).Contains("uses raw message delivery");
+        await Assert.That(description).DoesNotContain("notification envelope");
+    }
+
+    [Test]
+    public async Task APointToPointSubscriptionHasNoDeliveryModeDescription()
+    {
+        using var document = await GenerateAsync(rawMessageDelivery: false);
+        var root = document.RootElement;
+
+        // The SQS body of a point-to-point queue is the payload itself; there is no envelope to call out.
+        var operation = root.GetProperty("operations").GetProperty("receive-orderdispatched");
+        await Assert.That(operation.TryGetProperty("description", out _)).IsFalse();
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenDocumentingSnsDeliveryMode.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenDocumentingSnsDeliveryMode.cs
@@ -85,13 +85,16 @@ public class WhenDocumentingSnsDeliveryMode
     }
 
     [Test]
-    public async Task APointToPointSubscriptionHasNoDeliveryModeDescription()
+    public async Task APointToPointSubscriptionDescribesTheQueueEnvelopeInsteadOfSns()
     {
         using var document = await GenerateAsync(rawMessageDelivery: false);
         var root = document.RootElement;
 
-        // The SQS body of a point-to-point queue is the payload itself; there is no envelope to call out.
+        // A point-to-point queue never sees the SNS notification envelope, but its producer may wrap
+        // the payload in JustSaying's queue envelope, which the consumer accepts either way.
         var operation = root.GetProperty("operations").GetProperty("receive-orderdispatched");
-        await Assert.That(operation.TryGetProperty("description", out _)).IsFalse();
+        var description = operation.GetProperty("description").GetString();
+        await Assert.That(description).DoesNotContain("notification envelope");
+        await Assert.That(description).Contains("queue envelope");
     }
 }

--- a/tests/JustSaying.AsyncApi.Tests/WhenDocumentingTheQueueEnvelope.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenDocumentingTheQueueEnvelope.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using JustSaying.AwsTools;
+using JustSaying.Fluent;
+using JustSaying.Messaging.MessageHandling;
 using JustSaying.TestingFramework;
 using LocalSqsSnsMessaging;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,11 +20,22 @@ public class WhenDocumentingTheQueueEnvelope
         public string OrderId { get; set; }
     }
 
-    private static async Task<JsonDocument> GenerateAsync(bool rawMessages)
+    public sealed class ParcelShipped
+    {
+        public string ParcelId { get; set; }
+    }
+
+    public sealed class OrderPlacedHandler : IHandlerAsync<OrderPlaced>
+    {
+        public Task<bool> Handle(OrderPlaced message) => Task.FromResult(true);
+    }
+
+    private static async Task<JsonDocument> GenerateAsync(bool rawMessages, bool subscribe = false, bool mixedQueue = false)
     {
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton<IAwsClientFactory>(new LocalAwsClientFactory(new InMemoryAwsBus()));
+        services.AddJustSayingCloudEvents((options) => options.Source = new Uri("https://orders.example.com/"));
         services.AddJustSaying((config) =>
         {
             config.Messaging((x) => x.WithRegion("eu-west-1"));
@@ -36,8 +49,26 @@ public class WhenDocumentingTheQueueEnvelope
                     }
                 });
                 x.WithTopic<OrderDispatched>();
+
+                if (mixedQueue)
+                {
+                    // A self-describing CloudEvent is never wrapped, even on the same queue.
+                    x.WithCloudEventQueue<ParcelShipped>(QueueDestination.Named("orderplaced"), "com.example.parcels.shipped");
+                }
             });
+
+            if (subscribe)
+            {
+                config.Subscriptions((x) => x.ForQueue<OrderPlaced>((queue) =>
+                {
+                    if (rawMessages)
+                    {
+                        queue.WithRawMessageDelivery();
+                    }
+                }));
+            }
         });
+        services.AddJustSayingHandler<OrderPlaced, OrderPlacedHandler>();
         services.AddJustSayingAsyncApi();
 
         var serviceProvider = services.BuildServiceProvider();
@@ -76,5 +107,38 @@ public class WhenDocumentingTheQueueEnvelope
         // Only SQS publications use the queue envelope; SNS carries the payload verbatim.
         var operation = document.RootElement.GetProperty("operations").GetProperty("send-orderdispatched");
         await Assert.That(operation.TryGetProperty("description", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task AMixedQueueDescribesWhichMessagesAreWrapped()
+    {
+        using var document = await GenerateAsync(rawMessages: false, mixedQueue: true);
+
+        var operation = document.RootElement.GetProperty("operations").GetProperty("send-orderplaced");
+        var description = operation.GetProperty("description").GetString();
+        await Assert.That(description).Contains("wraps OrderPlaced in JustSaying's queue envelope");
+        await Assert.That(description).Contains("ParcelShipped is sent verbatim");
+    }
+
+    [Test]
+    public async Task ADefaultQueueSubscriptionDescribesBothBodyShapes()
+    {
+        using var document = await GenerateAsync(rawMessages: false, subscribe: true);
+
+        // The consumer cannot know whether the producer wraps, so it accepts either shape.
+        var operation = document.RootElement.GetProperty("operations").GetProperty("receive-orderplaced");
+        var description = operation.GetProperty("description").GetString();
+        await Assert.That(description).Contains("either as the documented message payload or wrapped in JustSaying's queue envelope");
+    }
+
+    [Test]
+    public async Task ARawQueueSubscriptionDescribesRawDelivery()
+    {
+        using var document = await GenerateAsync(rawMessages: true, subscribe: true);
+
+        var operation = document.RootElement.GetProperty("operations").GetProperty("receive-orderplaced");
+        var description = operation.GetProperty("description").GetString();
+        await Assert.That(description).Contains("raw message delivery");
+        await Assert.That(description).DoesNotContain("queue envelope");
     }
 }

--- a/tests/JustSaying.AsyncApi.Tests/WhenDocumentingTheQueueEnvelope.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenDocumentingTheQueueEnvelope.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using JustSaying.AwsTools;
+using JustSaying.TestingFramework;
+using LocalSqsSnsMessaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenDocumentingTheQueueEnvelope
+{
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    public sealed class OrderDispatched
+    {
+        public string OrderId { get; set; }
+    }
+
+    private static async Task<JsonDocument> GenerateAsync(bool rawMessages)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IAwsClientFactory>(new LocalAwsClientFactory(new InMemoryAwsBus()));
+        services.AddJustSaying((config) =>
+        {
+            config.Messaging((x) => x.WithRegion("eu-west-1"));
+            config.Publications((x) =>
+            {
+                x.WithQueue<OrderPlaced>((queue) =>
+                {
+                    if (rawMessages)
+                    {
+                        queue.WithRawMessages();
+                    }
+                });
+                x.WithTopic<OrderDispatched>();
+            });
+        });
+        services.AddJustSayingAsyncApi();
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IAsyncApiDocumentProvider>();
+        using var writer = new StringWriter();
+        await provider.GenerateAsync(provider.GetDocumentNames()[0], writer);
+        return JsonDocument.Parse(writer.ToString());
+    }
+
+    [Test]
+    public async Task ADefaultQueuePublicationDescribesTheQueueEnvelope()
+    {
+        using var document = await GenerateAsync(rawMessages: false);
+
+        var operation = document.RootElement.GetProperty("operations").GetProperty("send-orderplaced");
+        var description = operation.GetProperty("description").GetString();
+        await Assert.That(description).Contains("JustSaying's queue envelope");
+        await Assert.That(description).Contains("\"Message\"");
+    }
+
+    [Test]
+    public async Task ARawQueuePublicationHasNoEnvelopeDescription()
+    {
+        using var document = await GenerateAsync(rawMessages: true);
+
+        // The SQS body is the payload itself, which is what the message schema already documents.
+        var operation = document.RootElement.GetProperty("operations").GetProperty("send-orderplaced");
+        await Assert.That(operation.TryGetProperty("description", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task ATopicPublicationHasNoEnvelopeDescription()
+    {
+        using var document = await GenerateAsync(rawMessages: false);
+
+        // Only SQS publications use the queue envelope; SNS carries the payload verbatim.
+        var operation = document.RootElement.GetProperty("operations").GetProperty("send-orderdispatched");
+        await Assert.That(operation.TryGetProperty("description", out _)).IsFalse();
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenGeneratingAnAsyncApiDocument.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenGeneratingAnAsyncApiDocument.cs
@@ -60,7 +60,9 @@ public class WhenGeneratingAnAsyncApiDocument
         using var document = await GenerateAsync(BuildServiceProvider());
         var root = document.RootElement;
 
-        await Assert.That(root.GetProperty("asyncapi").GetString()).StartsWith("3.");
+        // ByteBard hardcodes the emitted spec version; the public docs say 3.1, so a ByteBard
+        // upgrade that changes the emitted version must fail here and be reflected in the docs.
+        await Assert.That(root.GetProperty("asyncapi").GetString()).IsEqualTo("3.1.0");
         await Assert.That(root.GetProperty("info").GetProperty("title").GetString()).IsEqualTo("Orders");
         await Assert.That(root.GetProperty("info").GetProperty("version").GetString()).IsEqualTo("2.1.0");
 

--- a/tests/JustSaying.AsyncApi.Tests/WhenGeneratingAnAsyncApiDocument.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenGeneratingAnAsyncApiDocument.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+using JustSaying.AwsTools;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.TestingFramework;
+using LocalSqsSnsMessaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenGeneratingAnAsyncApiDocument
+{
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+        public decimal Total { get; set; }
+    }
+
+    public sealed class OrderReady
+    {
+        public string OrderId { get; set; }
+    }
+
+    public sealed class OrderPlacedHandler : IHandlerAsync<OrderPlaced>
+    {
+        public Task<bool> Handle(OrderPlaced message) => Task.FromResult(true);
+    }
+
+    private static IServiceProvider BuildServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IAwsClientFactory>(new LocalAwsClientFactory(new InMemoryAwsBus()));
+        services.AddJustSaying((config) =>
+        {
+            config.Messaging((x) => x.WithRegion("eu-west-1"));
+            config.Publications((x) => x.WithTopic<OrderReady>());
+            config.Subscriptions((x) => x.ForTopic<OrderPlaced>());
+        });
+        services.AddJustSayingHandler<OrderPlaced, OrderPlacedHandler>();
+        services.AddJustSayingAsyncApi((options) =>
+        {
+            options.Title = "Orders";
+            options.Version = "2.1.0";
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task<JsonDocument> GenerateAsync(IServiceProvider serviceProvider)
+    {
+        var provider = serviceProvider.GetRequiredService<IAsyncApiDocumentProvider>();
+        using var writer = new StringWriter();
+        await provider.GenerateAsync(provider.GetDocumentNames()[0], writer);
+        return JsonDocument.Parse(writer.ToString());
+    }
+
+    [Test]
+    public async Task TheDocumentDescribesTheBus()
+    {
+        using var document = await GenerateAsync(BuildServiceProvider());
+        var root = document.RootElement;
+
+        await Assert.That(root.GetProperty("asyncapi").GetString()).StartsWith("3.");
+        await Assert.That(root.GetProperty("info").GetProperty("title").GetString()).IsEqualTo("Orders");
+        await Assert.That(root.GetProperty("info").GetProperty("version").GetString()).IsEqualTo("2.1.0");
+
+        var servers = root.GetProperty("servers");
+        await Assert.That(servers.GetProperty("sns").GetProperty("host").GetString()).IsEqualTo("sns.eu-west-1.amazonaws.com");
+        await Assert.That(servers.GetProperty("sqs").GetProperty("protocol").GetString()).IsEqualTo("sqs");
+    }
+
+    [Test]
+    public async Task TheTopicPublicationBecomesASendOperation()
+    {
+        using var document = await GenerateAsync(BuildServiceProvider());
+        var root = document.RootElement;
+
+        var channel = root.GetProperty("channels").GetProperty("orderready");
+        await Assert.That(channel.GetProperty("address").GetString()).IsEqualTo("orderready");
+
+        var operation = root.GetProperty("operations").GetProperty("send-orderready");
+        await Assert.That(operation.GetProperty("action").GetString()).IsEqualTo("send");
+        await Assert.That(operation.GetProperty("channel").GetProperty("$ref").GetString()).IsEqualTo("#/channels/orderready");
+    }
+
+    [Test]
+    public async Task TheTopicSubscriptionBecomesAReceiveOperationOnTheQueueChannel()
+    {
+        using var document = await GenerateAsync(BuildServiceProvider());
+        var root = document.RootElement;
+
+        var channel = root.GetProperty("channels").GetProperty("orderplaced");
+        await Assert.That(channel.GetProperty("address").GetString()).IsEqualTo("orderplaced");
+        await Assert.That(channel.GetProperty("description").GetString()).Contains("subscribed to the orderplaced SNS topic");
+
+        var operation = root.GetProperty("operations").GetProperty("receive-orderplaced");
+        await Assert.That(operation.GetProperty("action").GetString()).IsEqualTo("receive");
+    }
+
+    [Test]
+    public async Task TheMessagePayloadHasASchema()
+    {
+        using var document = await GenerateAsync(BuildServiceProvider());
+        var root = document.RootElement;
+
+        var message = root.GetProperty("channels").GetProperty("orderplaced").GetProperty("messages").EnumerateObject().First().Value;
+        var payload = message.GetProperty("payload");
+
+        await Assert.That(payload.GetProperty("type").GetString()).IsEqualTo("object");
+        var properties = payload.GetProperty("properties");
+        await Assert.That(properties.TryGetProperty("OrderId", out _)).IsTrue();
+        await Assert.That(properties.TryGetProperty("Total", out _)).IsTrue();
+    }
+
+    [Test]
+    public async Task TheBusIsNotStartedByDocumentGeneration()
+    {
+        var serviceProvider = BuildServiceProvider();
+        using var document = await GenerateAsync(serviceProvider);
+
+        // Interrogation exposes the subscription groups only once the bus has started.
+        var bus = serviceProvider.GetRequiredService<IMessagingBus>();
+        using var data = JsonDocument.Parse(Newtonsoft.Json.JsonConvert.SerializeObject(bus.Interrogate()));
+        var root = data.RootElement.TryGetProperty("Data", out var unwrapped) ? unwrapped : data.RootElement;
+        await Assert.That(root.GetProperty("SubscriptionGroups").ValueKind).IsEqualTo(JsonValueKind.Null);
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenGeneratingAnAsyncApiDocument.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenGeneratingAnAsyncApiDocument.cs
@@ -113,6 +113,16 @@ public class WhenGeneratingAnAsyncApiDocument
     }
 
     [Test]
+    public async Task CancellationIsObservedWhenWritingTheDocument()
+    {
+        var provider = BuildServiceProvider().GetRequiredService<IAsyncApiDocumentProvider>();
+        using var writer = new StringWriter();
+
+        await Assert.That(async () => await provider.GenerateAsync(provider.GetDocumentNames()[0], writer, new CancellationToken(canceled: true)))
+            .Throws<OperationCanceledException>();
+    }
+
+    [Test]
     public async Task TheBusIsNotStartedByDocumentGeneration()
     {
         var serviceProvider = BuildServiceProvider();

--- a/tests/JustSaying.AsyncApi.Tests/WhenGeneratingAtBuildTime.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenGeneratingAtBuildTime.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.Json;
+
+namespace JustSaying.AsyncApi.Tests;
+
+/// <summary>
+/// Exercises the JustSaying.AsyncApi.GetDocument tool end to end, invoking it the same way the
+/// JustSaying.AsyncApi.BuildTools MSBuild targets do: <c>dotnet exec</c> with the application's
+/// deps.json and runtimeconfig.json, against a real compiled application
+/// (JustSaying.AsyncApi.Tests.App).
+/// </summary>
+public class WhenGeneratingAtBuildTime
+{
+    private sealed record ToolResult(int ExitCode, string StandardOutput, string StandardError);
+
+    [Test]
+    public async Task TheDocumentIsWrittenToTheOutputDirectory()
+    {
+        using var outputDirectory = new TemporaryDirectory();
+
+        var result = await RunTool(outputDirectory.Path);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"The tool exited with code {result.ExitCode}.{Environment.NewLine}{result.StandardError}{Environment.NewLine}{result.StandardOutput}");
+        }
+
+        var documentPath = Path.Combine(outputDirectory.Path, "asyncapi.json");
+        await Assert.That(File.Exists(documentPath)).IsTrue();
+
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(documentPath));
+        await Assert.That(document.RootElement.GetProperty("info").GetProperty("title").GetString()).IsEqualTo("Test App");
+        await Assert.That(document.RootElement.GetProperty("channels").TryGetProperty("orderreadyevent", out _)).IsTrue();
+
+        var fileList = await File.ReadAllLinesAsync(Path.Combine(outputDirectory.Path, "files.txt"));
+        await Assert.That(fileList).Contains(documentPath);
+    }
+
+    [Test]
+    public async Task AnUnchangedDocumentIsNotRewritten()
+    {
+        using var outputDirectory = new TemporaryDirectory();
+        var documentPath = Path.Combine(outputDirectory.Path, "asyncapi.json");
+
+        var firstRun = await RunTool(outputDirectory.Path);
+        await Assert.That(firstRun.ExitCode).IsEqualTo(0);
+        var writtenAt = File.GetLastWriteTimeUtc(documentPath);
+
+        var secondRun = await RunTool(outputDirectory.Path);
+
+        await Assert.That(secondRun.ExitCode).IsEqualTo(0);
+        await Assert.That(secondRun.StandardOutput).Contains("is up to date");
+        await Assert.That(File.GetLastWriteTimeUtc(documentPath)).IsEqualTo(writtenAt);
+    }
+
+    [Test]
+    public async Task AMissingHandlerFailsWithAnErrorExplainingWhatToRegister()
+    {
+        using var outputDirectory = new TemporaryDirectory();
+
+        var result = await RunTool(outputDirectory.Path, ("JUSTSAYING_TESTAPP_SKIP_HANDLER", "1"));
+
+        await Assert.That(result.ExitCode).IsNotEqualTo(0);
+        await Assert.That(result.StandardError).Contains("error JSAA");
+        await Assert.That(result.StandardError).Contains("AddJustSayingHandler");
+    }
+
+    [Test]
+    public async Task AMissingAsyncApiRegistrationFailsWithAnErrorNamingTheRegistrationMethod()
+    {
+        using var outputDirectory = new TemporaryDirectory();
+
+        var result = await RunTool(outputDirectory.Path, ("JUSTSAYING_TESTAPP_SKIP_ASYNCAPI", "1"));
+
+        await Assert.That(result.ExitCode).IsNotEqualTo(0);
+        await Assert.That(result.StandardError).Contains("error JSAA");
+        await Assert.That(result.StandardError).Contains("AddJustSayingAsyncApi");
+    }
+
+    private static async Task<ToolResult> RunTool(string outputDirectory, params (string Name, string Value)[] environment)
+    {
+        var appDirectory = GetAssemblyMetadata("TestAppDirectory");
+        var toolPath = GetAssemblyMetadata("GetDocumentToolPath");
+        var appPath = Path.Combine(appDirectory, "JustSaying.AsyncApi.Tests.App.dll");
+
+        var startInfo = new ProcessStartInfo()
+        {
+            FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet",
+            WorkingDirectory = appDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            ArgumentList =
+            {
+                "exec",
+                "--depsfile",
+                Path.Combine(appDirectory, "JustSaying.AsyncApi.Tests.App.deps.json"),
+                "--runtimeconfig",
+                Path.Combine(appDirectory, "JustSaying.AsyncApi.Tests.App.runtimeconfig.json"),
+                toolPath,
+                "--assembly",
+                appPath,
+                "--output",
+                outputDirectory,
+                "--file-list",
+                Path.Combine(outputDirectory, "files.txt"),
+            },
+        };
+
+        foreach (var (name, value) in environment)
+        {
+            startInfo.Environment[name] = value;
+        }
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start the tool process.");
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("The tool did not exit within three minutes.");
+        }
+
+        return new ToolResult(process.ExitCode, await standardOutput, await standardError);
+    }
+
+    private static string GetAssemblyMetadata(string key)
+    {
+        return typeof(WhenGeneratingAtBuildTime).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single((attribute) => attribute.Key == key)
+            .Value;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "justsaying-asyncapi-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Best effort; the OS cleans the temp directory eventually.
+            }
+        }
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenGeneratingAtBuildTime.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenGeneratingAtBuildTime.cs
@@ -56,6 +56,48 @@ public class WhenGeneratingAtBuildTime
     }
 
     [Test]
+    public async Task TheFileNameCanBeOverridden()
+    {
+        using var outputDirectory = new TemporaryDirectory();
+
+        var result = await RunTool(outputDirectory.Path, extraArguments: ["--file-name", "My.Sample-App"]);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        var documentPath = Path.Combine(outputDirectory.Path, "My.Sample-App.json");
+        await Assert.That(File.Exists(documentPath)).IsTrue();
+
+        var fileList = await File.ReadAllLinesAsync(Path.Combine(outputDirectory.Path, "files.txt"));
+        await Assert.That(fileList).Contains(documentPath);
+    }
+
+    [Test]
+    public async Task AnInvalidFileNameFailsWithAnError()
+    {
+        using var outputDirectory = new TemporaryDirectory();
+
+        var result = await RunTool(outputDirectory.Path, extraArguments: ["--file-name", "not/a valid?name"]);
+
+        await Assert.That(result.ExitCode).IsNotEqualTo(0);
+        await Assert.That(result.StandardError).Contains("error JSAA");
+        await Assert.That(result.StandardError).Contains("file name");
+    }
+
+    [Test]
+    public async Task ASlowEntryPointFailsFastWithTheConfiguredTimeout()
+    {
+        using var outputDirectory = new TemporaryDirectory();
+
+        var result = await RunTool(
+            outputDirectory.Path,
+            extraArguments: ["--entry-point-timeout", "2"],
+            ("JUSTSAYING_TESTAPP_BLOCK_STARTUP", "1"));
+
+        await Assert.That(result.ExitCode).IsNotEqualTo(0);
+        await Assert.That(result.StandardError).Contains("error JSAA");
+        await Assert.That(result.StandardError).Contains("JustSayingAsyncApiEntryPointTimeoutSeconds");
+    }
+
+    [Test]
     public async Task AMissingHandlerFailsWithAnErrorExplainingWhatToRegister()
     {
         using var outputDirectory = new TemporaryDirectory();
@@ -79,7 +121,13 @@ public class WhenGeneratingAtBuildTime
         await Assert.That(result.StandardError).Contains("AddJustSayingAsyncApi");
     }
 
-    private static async Task<ToolResult> RunTool(string outputDirectory, params (string Name, string Value)[] environment)
+    private static Task<ToolResult> RunTool(string outputDirectory, params (string Name, string Value)[] environment)
+        => RunTool(outputDirectory, extraArguments: [], environment);
+
+    private static async Task<ToolResult> RunTool(
+        string outputDirectory,
+        string[] extraArguments,
+        params (string Name, string Value)[] environment)
     {
         var appDirectory = GetAssemblyMetadata("TestAppDirectory");
         var toolPath = GetAssemblyMetadata("GetDocumentToolPath");
@@ -107,6 +155,11 @@ public class WhenGeneratingAtBuildTime
                 Path.Combine(outputDirectory, "files.txt"),
             },
         };
+
+        foreach (var argument in extraArguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
 
         foreach (var (name, value) in environment)
         {

--- a/tests/JustSaying.AsyncApi.Tests/WhenGeneratingWithCloudEventsAndMultiTypeQueues.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenGeneratingWithCloudEventsAndMultiTypeQueues.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using JustSaying.AwsTools;
+using JustSaying.CloudEvents;
+using JustSaying.Fluent;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.TestingFramework;
 using LocalSqsSnsMessaging;
@@ -7,8 +9,17 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace JustSaying.AsyncApi.Tests;
 
+/// <summary>
+/// CloudEvents is opted into per registration, so the document must describe each message from the
+/// serializer its registration actually uses: a <c>WithCloudEventTopic</c> publication and the
+/// <c>HandlingCloudEvent</c>/<c>HandlingCloudEventData</c> subscriptions are CloudEvents, while a plain
+/// <c>WithTopic</c> in the same application stays plain JSON.
+/// </summary>
 public class WhenGeneratingWithCloudEventsAndMultiTypeQueues
 {
+    private const string OrderPlacedType = "com.example.orders.placed";
+    private const string OrderCancelledType = "com.example.orders.cancelled";
+
     public sealed class OrderPlaced
     {
         public string OrderId { get; set; }
@@ -19,9 +30,14 @@ public class WhenGeneratingWithCloudEventsAndMultiTypeQueues
         public string OrderId { get; set; }
     }
 
-    public sealed class OrderPlacedHandler : IHandlerAsync<OrderPlaced>
+    public sealed class OrderReady
     {
-        public Task<bool> Handle(OrderPlaced message) => Task.FromResult(true);
+        public string OrderId { get; set; }
+    }
+
+    public sealed class OrderPlacedHandler : IHandlerAsync<CloudEvent<OrderPlaced>>
+    {
+        public Task<bool> Handle(CloudEvent<OrderPlaced> message) => Task.FromResult(true);
     }
 
     public sealed class OrderCancelledHandler : IHandlerAsync<OrderCancelled>
@@ -29,26 +45,33 @@ public class WhenGeneratingWithCloudEventsAndMultiTypeQueues
         public Task<bool> Handle(OrderCancelled message) => Task.FromResult(true);
     }
 
-    private static async Task<JsonDocument> GenerateAsync()
+    private static async Task<JsonDocument> GenerateAsync(bool useAsDefault = false)
     {
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton<IAwsClientFactory>(new LocalAwsClientFactory(new InMemoryAwsBus()));
-        services.AddJustSayingCloudEvents((options) =>
-        {
-            options.Source = new Uri("https://orders.example.com/");
-            options.MapType<OrderPlaced>("com.example.orders.placed");
-            options.MapType<OrderCancelled>("com.example.orders.cancelled");
-        });
+        services.AddJustSayingCloudEvents(
+            (options) =>
+            {
+                options.Source = new Uri("https://orders.example.com/");
+                options.MapType<OrderPlaced>(OrderPlacedType);
+                options.MapType<OrderCancelled>(OrderCancelledType);
+                options.MapType<OrderReady>("com.example.orders.ready");
+            },
+            useAsDefault: useAsDefault);
         services.AddJustSaying((config) =>
         {
             config.Messaging((x) => x.WithRegion("eu-west-1"));
-            config.Publications((x) => x.WithTopic<OrderPlaced>());
+            config.Publications((x) =>
+            {
+                x.WithCloudEventTopic<OrderPlaced>(OrderPlacedType);
+                x.WithTopic<OrderReady>();
+            });
             config.Subscriptions((x) => x.ForQueue("orders", (q) =>
-                q.Handling<OrderPlaced>("com.example.orders.placed")
-                    .Handling<OrderCancelled>("com.example.orders.cancelled")));
+                q.HandlingCloudEvent<OrderPlaced>(OrderPlacedType)
+                    .HandlingCloudEventData<OrderCancelled>(OrderCancelledType)));
         });
-        services.AddJustSayingHandler<OrderPlaced, OrderPlacedHandler>();
+        services.AddJustSayingHandler<CloudEvent<OrderPlaced>, OrderPlacedHandler>();
         services.AddJustSayingHandler<OrderCancelled, OrderCancelledHandler>();
         services.AddJustSayingAsyncApi();
 
@@ -66,9 +89,26 @@ public class WhenGeneratingWithCloudEventsAndMultiTypeQueues
         var root = document.RootElement;
 
         var messages = root.GetProperty("channels").GetProperty("orderplaced").GetProperty("messages");
-        await Assert.That(messages.TryGetProperty("com.example.orders.placed", out var message)).IsTrue();
-        await Assert.That(message.GetProperty("name").GetString()).IsEqualTo("com.example.orders.placed");
+        await Assert.That(messages.TryGetProperty(OrderPlacedType, out var message)).IsTrue();
+        await Assert.That(message.GetProperty("name").GetString()).IsEqualTo(OrderPlacedType);
+        await Assert.That(message.GetProperty("title").GetString()).IsEqualTo(nameof(OrderPlaced));
         await Assert.That(message.GetProperty("contentType").GetString()).IsEqualTo("application/cloudevents+json");
+    }
+
+    [Test]
+    public async Task BothPublishShapesOfACloudEventAreOneMessage()
+    {
+        using var document = await GenerateAsync();
+        var root = document.RootElement;
+
+        // WithCloudEventTopic<T> registers the bare T and the CloudEvent<T> envelope against one
+        // topic; on the wire they are the same CloudEvent, so the document has one message.
+        var messages = root.GetProperty("channels").GetProperty("orderplaced").GetProperty("messages");
+        await Assert.That(messages.EnumerateObject().Count()).IsEqualTo(1);
+
+        var operation = root.GetProperty("operations").GetProperty("send-orderplaced");
+        await Assert.That(operation.GetProperty("messages").GetArrayLength()).IsEqualTo(1);
+        await Assert.That(operation.GetProperty("summary").GetString()).IsEqualTo($"Publish {nameof(OrderPlaced)} to orderplaced.");
     }
 
     [Test]
@@ -77,14 +117,15 @@ public class WhenGeneratingWithCloudEventsAndMultiTypeQueues
         using var document = await GenerateAsync();
         var root = document.RootElement;
 
-        var message = root.GetProperty("channels").GetProperty("orderplaced").GetProperty("messages").GetProperty("com.example.orders.placed");
+        var message = root.GetProperty("channels").GetProperty("orderplaced").GetProperty("messages").GetProperty(OrderPlacedType);
         var payload = message.GetProperty("payload");
 
         // The wire format is the CloudEvents structured-mode envelope, not the bare data schema.
         var properties = payload.GetProperty("properties");
         await Assert.That(properties.GetProperty("specversion").GetProperty("const").GetString()).IsEqualTo("1.0");
-        await Assert.That(properties.GetProperty("type").GetProperty("const").GetString()).IsEqualTo("com.example.orders.placed");
+        await Assert.That(properties.GetProperty("type").GetProperty("const").GetString()).IsEqualTo(OrderPlacedType);
         await Assert.That(properties.GetProperty("source").GetProperty("format").GetString()).IsEqualTo("uri-reference");
+        await Assert.That(properties.GetProperty("datacontenttype").GetProperty("const").GetString()).IsEqualTo("application/json");
 
         var required = payload.GetProperty("required").EnumerateArray().Select((r) => r.GetString()).ToList();
         await Assert.That(required).Contains("data");
@@ -101,10 +142,46 @@ public class WhenGeneratingWithCloudEventsAndMultiTypeQueues
 
         var channel = root.GetProperty("channels").GetProperty("orders");
         var messages = channel.GetProperty("messages");
-        await Assert.That(messages.TryGetProperty("com.example.orders.placed", out _)).IsTrue();
-        await Assert.That(messages.TryGetProperty("com.example.orders.cancelled", out _)).IsTrue();
+        await Assert.That(messages.TryGetProperty(OrderPlacedType, out var placed)).IsTrue();
+        await Assert.That(messages.TryGetProperty(OrderCancelledType, out var cancelled)).IsTrue();
+
+        // Whether the handler receives the envelope or just its data, the wire format is a CloudEvent.
+        await Assert.That(placed.GetProperty("title").GetString()).IsEqualTo(nameof(OrderPlaced));
+        await Assert.That(placed.GetProperty("contentType").GetString()).IsEqualTo("application/cloudevents+json");
+        await Assert.That(cancelled.GetProperty("contentType").GetString()).IsEqualTo("application/cloudevents+json");
+        await Assert.That(cancelled.GetProperty("payload").GetProperty("properties").GetProperty("type").GetProperty("const").GetString()).IsEqualTo(OrderCancelledType);
 
         var operation = root.GetProperty("operations").GetProperty("receive-orders");
         await Assert.That(operation.GetProperty("messages").GetArrayLength()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task APlainPublicationInTheSameApplicationStaysPlainJson()
+    {
+        using var document = await GenerateAsync();
+        var root = document.RootElement;
+
+        // CloudEvents support was added without useAsDefault, so WithTopic<OrderReady> still
+        // publishes plain JSON even though OrderReady has a CloudEvents type mapped.
+        var message = root.GetProperty("channels").GetProperty("orderready").GetProperty("messages").GetProperty(nameof(OrderReady));
+        await Assert.That(message.GetProperty("contentType").GetString()).IsEqualTo("application/json");
+        await Assert.That(message.GetProperty("payload").GetProperty("properties").TryGetProperty("OrderId", out _)).IsTrue();
+        await Assert.That(message.GetProperty("payload").GetProperty("properties").TryGetProperty("specversion", out _)).IsFalse();
+
+        // Formats are mixed, so the document-level default is plain JSON.
+        await Assert.That(root.GetProperty("defaultContentType").GetString()).IsEqualTo("application/json");
+    }
+
+    [Test]
+    public async Task WhenCloudEventsIsTheDefaultEveryRegistrationIsACloudEvent()
+    {
+        using var document = await GenerateAsync(useAsDefault: true);
+        var root = document.RootElement;
+
+        var message = root.GetProperty("channels").GetProperty("orderready").GetProperty("messages").GetProperty("com.example.orders.ready");
+        await Assert.That(message.GetProperty("contentType").GetString()).IsEqualTo("application/cloudevents+json");
+        await Assert.That(message.GetProperty("payload").GetProperty("properties").GetProperty("type").GetProperty("const").GetString()).IsEqualTo("com.example.orders.ready");
+
+        await Assert.That(root.GetProperty("defaultContentType").GetString()).IsEqualTo("application/cloudevents+json");
     }
 }

--- a/tests/JustSaying.AsyncApi.Tests/WhenGeneratingWithCloudEventsAndMultiTypeQueues.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenGeneratingWithCloudEventsAndMultiTypeQueues.cs
@@ -72,6 +72,28 @@ public class WhenGeneratingWithCloudEventsAndMultiTypeQueues
     }
 
     [Test]
+    public async Task ThePayloadDocumentsTheCloudEventsEnvelope()
+    {
+        using var document = await GenerateAsync();
+        var root = document.RootElement;
+
+        var message = root.GetProperty("channels").GetProperty("orderplaced").GetProperty("messages").GetProperty("com.example.orders.placed");
+        var payload = message.GetProperty("payload");
+
+        // The wire format is the CloudEvents structured-mode envelope, not the bare data schema.
+        var properties = payload.GetProperty("properties");
+        await Assert.That(properties.GetProperty("specversion").GetProperty("const").GetString()).IsEqualTo("1.0");
+        await Assert.That(properties.GetProperty("type").GetProperty("const").GetString()).IsEqualTo("com.example.orders.placed");
+        await Assert.That(properties.GetProperty("source").GetProperty("format").GetString()).IsEqualTo("uri-reference");
+
+        var required = payload.GetProperty("required").EnumerateArray().Select((r) => r.GetString()).ToList();
+        await Assert.That(required).Contains("data");
+
+        var dataProperties = properties.GetProperty("data").GetProperty("properties");
+        await Assert.That(dataProperties.TryGetProperty("OrderId", out _)).IsTrue();
+    }
+
+    [Test]
     public async Task AMultiTypeQueueBecomesOneChannelWithAMessagesMap()
     {
         using var document = await GenerateAsync();

--- a/tests/JustSaying.AsyncApi.Tests/WhenGeneratingWithCloudEventsAndMultiTypeQueues.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenGeneratingWithCloudEventsAndMultiTypeQueues.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using JustSaying.AwsTools;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.TestingFramework;
+using LocalSqsSnsMessaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenGeneratingWithCloudEventsAndMultiTypeQueues
+{
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    public sealed class OrderCancelled
+    {
+        public string OrderId { get; set; }
+    }
+
+    public sealed class OrderPlacedHandler : IHandlerAsync<OrderPlaced>
+    {
+        public Task<bool> Handle(OrderPlaced message) => Task.FromResult(true);
+    }
+
+    public sealed class OrderCancelledHandler : IHandlerAsync<OrderCancelled>
+    {
+        public Task<bool> Handle(OrderCancelled message) => Task.FromResult(true);
+    }
+
+    private static async Task<JsonDocument> GenerateAsync()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IAwsClientFactory>(new LocalAwsClientFactory(new InMemoryAwsBus()));
+        services.AddJustSayingCloudEvents((options) =>
+        {
+            options.Source = new Uri("https://orders.example.com/");
+            options.MapType<OrderPlaced>("com.example.orders.placed");
+            options.MapType<OrderCancelled>("com.example.orders.cancelled");
+        });
+        services.AddJustSaying((config) =>
+        {
+            config.Messaging((x) => x.WithRegion("eu-west-1"));
+            config.Publications((x) => x.WithTopic<OrderPlaced>());
+            config.Subscriptions((x) => x.ForQueue("orders", (q) =>
+                q.Handling<OrderPlaced>("com.example.orders.placed")
+                    .Handling<OrderCancelled>("com.example.orders.cancelled")));
+        });
+        services.AddJustSayingHandler<OrderPlaced, OrderPlacedHandler>();
+        services.AddJustSayingHandler<OrderCancelled, OrderCancelledHandler>();
+        services.AddJustSayingAsyncApi();
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IAsyncApiDocumentProvider>();
+        using var writer = new StringWriter();
+        await provider.GenerateAsync(provider.GetDocumentNames()[0], writer);
+        return JsonDocument.Parse(writer.ToString());
+    }
+
+    [Test]
+    public async Task MessagesAreNamedByTheirCloudEventType()
+    {
+        using var document = await GenerateAsync();
+        var root = document.RootElement;
+
+        var messages = root.GetProperty("channels").GetProperty("orderplaced").GetProperty("messages");
+        await Assert.That(messages.TryGetProperty("com.example.orders.placed", out var message)).IsTrue();
+        await Assert.That(message.GetProperty("name").GetString()).IsEqualTo("com.example.orders.placed");
+        await Assert.That(message.GetProperty("contentType").GetString()).IsEqualTo("application/cloudevents+json");
+    }
+
+    [Test]
+    public async Task AMultiTypeQueueBecomesOneChannelWithAMessagesMap()
+    {
+        using var document = await GenerateAsync();
+        var root = document.RootElement;
+
+        var channel = root.GetProperty("channels").GetProperty("orders");
+        var messages = channel.GetProperty("messages");
+        await Assert.That(messages.TryGetProperty("com.example.orders.placed", out _)).IsTrue();
+        await Assert.That(messages.TryGetProperty("com.example.orders.cancelled", out _)).IsTrue();
+
+        var operation = root.GetProperty("operations").GetProperty("receive-orders");
+        await Assert.That(operation.GetProperty("messages").GetArrayLength()).IsEqualTo(2);
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenKeysCollide.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenKeysCollide.cs
@@ -1,0 +1,85 @@
+using ByteBard.AsyncAPI.Models;
+using JustSaying.Messaging.Metadata;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenKeysCollide
+{
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    public sealed class OrderReady
+    {
+        public string OrderId { get; set; }
+    }
+
+    [Test]
+    public async Task WireNamesThatSanitizeToTheSameKeyBecomeDistinctMessages()
+    {
+        var registry = new MessagingMetadataRegistry();
+        registry.SetRegion("eu-west-1");
+
+        // Neither wire name is a valid AsyncAPI key, and both sanitize to "orders_placed";
+        // one must not silently overwrite the other.
+        registry.AddPublication(new PublicationMetadata(
+            MessagingDestinationKind.SnsTopic,
+            "orders",
+            false,
+            [
+                new MessageTypeMetadata(typeof(OrderPlaced), "orders/placed"),
+                new MessageTypeMetadata(typeof(OrderReady), "orders_placed"),
+            ]));
+
+        var document = new AsyncApiDocumentGenerator(registry, new AsyncApiOptions()).Generate();
+
+        var channel = document.Channels["orders"];
+        await Assert.That(channel.Messages.Count).IsEqualTo(2);
+        await Assert.That(channel.Messages["orders_placed"].Name).IsEqualTo("orders/placed");
+        await Assert.That(channel.Messages["orders_placed-2"].Name).IsEqualTo("orders_placed");
+
+        // Both messages are referenced, and each reference resolves to the message it names.
+        var references = document.Operations["send-orders"].Messages
+            .Select((m) => ((AsyncApiMessageReference)m).Reference.Reference)
+            .ToList();
+
+        await Assert.That(references).Contains("#/channels/orders/messages/orders_placed");
+        await Assert.That(references).Contains("#/channels/orders/messages/orders_placed-2");
+    }
+
+    [Test]
+    public async Task ADestinationNamedLikeTheFallbackKeyDoesNotStealTheChannel()
+    {
+        var registry = new MessagingMetadataRegistry();
+        registry.SetRegion("eu-west-1");
+
+        MessageTypeMetadata[] placed = [new(typeof(OrderPlaced), "orderplaced")];
+        MessageTypeMetadata[] ready = [new(typeof(OrderReady), "orderready")];
+
+        // Four different destinations, three of which want the key "orders": the topic takes
+        // it, the queue of the same name falls back to "orders-queue", and the cross-region
+        // queue's last fallback is already occupied by a queue genuinely named that.
+        registry.AddPublication(new PublicationMetadata(MessagingDestinationKind.SnsTopic, "orders", false, placed));
+        registry.AddSubscription(new SubscriptionMetadata("orders", null, "orders", false, placed));
+        registry.AddSubscription(new SubscriptionMetadata("orders-queue-us-east-1", null, "orders", false, placed));
+        registry.AddSubscription(new SubscriptionMetadata("orders", null, "orders", false, ready, "us-east-1"));
+
+        var document = new AsyncApiDocumentGenerator(registry, new AsyncApiOptions()).Generate();
+
+        await Assert.That(document.Channels.Count).IsEqualTo(4);
+        await Assert.That(document.Channels["orders"].Address).IsEqualTo("orders");
+        await Assert.That(document.Channels["orders-queue"].Address).IsEqualTo("orders");
+        await Assert.That(document.Channels["orders-queue-us-east-1"].Address).IsEqualTo("orders-queue-us-east-1");
+
+        // The cross-region queue gets a channel of its own rather than mixing its messages
+        // into the queue that already owns the fallback key.
+        var crossRegion = document.Channels["orders-queue-us-east-1-2"];
+        await Assert.That(crossRegion.Address).IsEqualTo("orders");
+        await Assert.That(crossRegion.Messages.Keys).Contains("orderready");
+        await Assert.That(((AsyncApiServerReference)crossRegion.Servers[0]).Reference.Reference).IsEqualTo("#/servers/sqs-us-east-1");
+
+        await Assert.That(document.Channels["orders-queue-us-east-1"].Messages.Keys).Contains("orderplaced");
+        await Assert.That(document.Channels["orders-queue-us-east-1"].Messages.Count).IsEqualTo(1);
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenNoAwsClientFactoryIsRegistered.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenNoAwsClientFactoryIsRegistered.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using JustSaying.Messaging.MessageHandling;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenNoAwsClientFactoryIsRegistered
+{
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    public sealed class OrderPlacedHandler : IHandlerAsync<OrderPlaced>
+    {
+        public Task<bool> Handle(OrderPlaced message) => Task.FromResult(true);
+    }
+
+    [Test]
+    public async Task TheDocumentIsGeneratedWithTheDefaultClientFactory()
+    {
+        // Generation makes no AWS calls, so falling back to DefaultAwsClientFactory must work
+        // even where no AWS credentials can be resolved (for example on a CI agent).
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddJustSaying((config) =>
+        {
+            config.Messaging((x) => x.WithRegion("eu-west-1"));
+            config.Publications((x) => x.WithTopic<OrderPlaced>());
+            config.Subscriptions((x) => x.ForTopic<OrderPlaced>());
+        });
+        services.AddJustSayingHandler<OrderPlaced, OrderPlacedHandler>();
+        services.AddJustSayingAsyncApi();
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IAsyncApiDocumentProvider>();
+        using var writer = new StringWriter();
+        await provider.GenerateAsync(provider.GetDocumentNames()[0], writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        await Assert.That(root.GetProperty("channels").TryGetProperty("orderplaced", out _)).IsTrue();
+        await Assert.That(root.GetProperty("operations").TryGetProperty("send-orderplaced", out _)).IsTrue();
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenPartsOfTheDocumentAreOmitted.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenPartsOfTheDocumentAreOmitted.cs
@@ -1,0 +1,83 @@
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Metadata;
+using Microsoft.Extensions.Logging;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenPartsOfTheDocumentAreOmitted
+{
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    private sealed class CapturingLogger : ILogger<AsyncApiDocumentGenerator>
+    {
+        public List<string> Warnings { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+
+    [Test]
+    public async Task AnEmptyRegistryLogsAWarning()
+    {
+        var logger = new CapturingLogger();
+        var generator = new AsyncApiDocumentGenerator(new MessagingMetadataRegistry(), new AsyncApiOptions(), logger: logger);
+
+        generator.Generate();
+
+        await Assert.That(logger.Warnings).Contains((warning) => warning.Contains("no publications or subscriptions were captured"));
+    }
+
+    [Test]
+    public async Task ADynamicPublicationLogsAWarning()
+    {
+        var registry = new MessagingMetadataRegistry();
+        registry.SetRegion("eu-west-1");
+        registry.AddPublication(new PublicationMetadata(
+            MessagingDestinationKind.SnsTopic,
+            destinationName: null,
+            isDynamic: true,
+            [new MessageTypeMetadata(typeof(OrderPlaced), nameof(OrderPlaced))]));
+
+        var logger = new CapturingLogger();
+        var generator = new AsyncApiDocumentGenerator(registry, new AsyncApiOptions(), logger: logger);
+
+        var document = generator.Generate();
+
+        await Assert.That(document.Channels).IsEmpty();
+        await Assert.That(logger.Warnings).Contains((warning) => warning.Contains("dynamic destination") && warning.Contains(nameof(OrderPlaced)));
+    }
+
+    [Test]
+    public async Task ANonSystemTextJsonSerializerLogsAWarning()
+    {
+        var registry = new MessagingMetadataRegistry();
+        registry.SetRegion("eu-west-1");
+        registry.AddPublication(new PublicationMetadata(
+            MessagingDestinationKind.SnsTopic,
+            "order-placed",
+            isDynamic: false,
+            [new MessageTypeMetadata(typeof(OrderPlaced), nameof(OrderPlaced))]));
+
+        var logger = new CapturingLogger();
+#pragma warning disable IL2026, IL3050
+        var serializationFactory = new NewtonsoftSerializationFactory();
+#pragma warning restore IL2026, IL3050
+        var generator = new AsyncApiDocumentGenerator(registry, new AsyncApiOptions(), serializationFactory, logger: logger);
+
+        generator.Generate();
+
+        await Assert.That(logger.Warnings).Contains((warning) => warning.Contains("documented without payload schemas"));
+    }
+}

--- a/tests/JustSaying.AsyncApi.Tests/WhenTheSerializerIsNotSystemTextJson.cs
+++ b/tests/JustSaying.AsyncApi.Tests/WhenTheSerializerIsNotSystemTextJson.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using JustSaying.AwsTools;
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.TestingFramework;
+using LocalSqsSnsMessaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.AsyncApi.Tests;
+
+public class WhenTheSerializerIsNotSystemTextJson
+{
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    private static IServiceProvider BuildServiceProvider(Action<AsyncApiOptions> configure = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IAwsClientFactory>(new LocalAwsClientFactory(new InMemoryAwsBus()));
+#pragma warning disable IL2026, IL3050
+        services.AddSingleton<IMessageBodySerializationFactory>(new NewtonsoftSerializationFactory());
+#pragma warning restore IL2026, IL3050
+        services.AddJustSaying((config) =>
+        {
+            config.Messaging((x) => x.WithRegion("eu-west-1"));
+            config.Publications((x) => x.WithTopic<OrderPlaced>());
+        });
+        services.AddJustSayingAsyncApi(configure);
+
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task<JsonDocument> GenerateAsync(IServiceProvider serviceProvider)
+    {
+        var provider = serviceProvider.GetRequiredService<IAsyncApiDocumentProvider>();
+        using var writer = new StringWriter();
+        await provider.GenerateAsync(provider.GetDocumentNames()[0], writer);
+        return JsonDocument.Parse(writer.ToString());
+    }
+
+    [Test]
+    public async Task NoPayloadSchemaIsInferredForANewtonsoftSerializer()
+    {
+        using var document = await GenerateAsync(BuildServiceProvider());
+        var root = document.RootElement;
+
+        // A System.Text.Json-shaped schema could misdocument Newtonsoft's wire format (for
+        // example enums-as-strings), so the message is documented without a payload schema.
+        var message = root.GetProperty("channels").GetProperty("orderplaced").GetProperty("messages").EnumerateObject().First().Value;
+        await Assert.That(message.TryGetProperty("payload", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task ExplicitSerializerOptionsStillProduceAPayloadSchema()
+    {
+        using var document = await GenerateAsync(BuildServiceProvider((options) =>
+            options.SerializerOptions = JsonSerializerOptions.Default));
+        var root = document.RootElement;
+
+        var message = root.GetProperty("channels").GetProperty("orderplaced").GetProperty("messages").EnumerateObject().First().Value;
+        await Assert.That(message.GetProperty("payload").GetProperty("properties").TryGetProperty("OrderId", out _)).IsTrue();
+    }
+}


### PR DESCRIPTION
## v9 stacked PR — AsyncAPI document generation

Adds a `JustSaying.AsyncApi` package that generates an [AsyncAPI 3.0](https://www.asyncapi.com/docs/reference/specification/v3.0.0) document describing an app's publications and subscriptions — the messaging equivalent of ASP.NET Core's OpenAPI document. **Stacked on #2210** (which is stacked on #2184 → #2183 → #2182) — review/merge those first.

As far as I can tell no .NET messaging library has a first-party AsyncAPI story (MassTransit and aws-dotnet-messaging have nothing, NServiceBus has demo-only samples), so this would be a nice differentiator.

### The metadata seam (core)
- The fluent builders now record each publication/subscription (message CLR type, destination kind + resolved name, direction, subscription group, wire name) into an `IMessagingMetadataRegistry` — resolved via the `IServiceResolver` their `Configure` methods already take, so it's fully opt-in and costs nothing when unused.
- Everything is captured at configure time, before the bus starts and before any AWS call. This deliberately does **not** build on `Interrogate()` — that's diagnostic-only, keyed by `Type.Name`, and only populated after start.

### The package
- `services.AddJustSayingAsyncApi(o => { o.Title = "Orders"; ... })` — registers the registry and an `IAsyncApiDocumentProvider`.
- Mapping: publication → channel + `send` operation; subscription → channel + `receive` operation; a multi-type queue (#2184) → one channel with a messages map, which is exactly the AsyncAPI 3.0 model; CloudEvents registrations name messages by their CE `type`. Dynamic (`WithTopicName(Func<...>)`) destinations have no static address, so they're skipped.
- Payload schemas come from `JsonSchemaExporter`, driven by the app's actual serializer options — so the schema reflects the real wire contract, including the source-generated STJ path from #2183.
- Document model is [`ByteBard.AsyncAPI.NET`](https://github.com/ByteBardOrg/AsyncAPI.NET) (the official continuation of LEGO.AsyncAPI.NET) — core package only, zero transitive deps on net8.0.

### Where this is heading
The provider interface (`JustSaying.AsyncApi.IAsyncApiDocumentProvider`) has a deliberately stable full name and `GetDocumentNames()`/`GenerateAsync(name, TextWriter)` shape: it mirrors how ASP.NET Core's build-time OpenAPI tooling resolves `IDocumentProvider` by name from the app's captured host. I've spiked that mechanism (`HostFactoryResolver` + `stopApplication: true` — hosted services never start, so `bus.StartAsync`/AWS never runs) and it works; the follow-up PR is the `.targets` + insider tool packaging for `dotnet build`-time generation.

Outstanding actions:
- [x] Build-time tool package (`JustSaying.AsyncApi.BuildTools`: referencing it makes `dotnet build` write `asyncapi.json` next to the project)
- [ ] Optional `MapAsyncApi()` ASP.NET Core endpoint
- [x] Decide how to represent the CloudEvents envelope — the payload is now the CloudEvents 1.0 structured-mode envelope schema with the data schema nested under `data`
- [x] Rebase over #2210 — done; CloudEvents is per-registration there, so the fluent builders now capture each registration's actual serializer on its metadata and the generator describes every message from that (`ICloudEventMessageBodySerializer` / `ISystemTextJsonMessageBodySerializer`) rather than from whether `CloudEventOptions` is registered

10 new tests + 303/304 unit (one pre-existing flaky channels test) + 10 CloudEvents green; solution builds clean with analyzers on.

### Stack
1. #2182 — Foundation
2. #2183 — Native AOT
3. #2184 — CloudEvents + multi-type-per-queue
4. #2210 — `CloudEvent<T>` wrapper
5. **this PR** — AsyncAPI (base: `slang25/v9-cloudevents-wrapper`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
