### PR TITLE
Cancel in-flight receive call when paused

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -134,12 +134,12 @@ ForEach ($libraryProject in $libraryProjects) {
 }
 
 if (($null -ne $env:CI) -And ($EnableIntegrationTests -eq $true)) {
-    $LocalStackImage = "localstack/localstack:3.5.0"
-    $LocalStackPort = "4566"
+    $FlociImage = "floci/floci:1.6.0"
+    $FlociPort = "4566"
     $containerRunner = Get-ContainerRunnerCommand
-    & $containerRunner pull --quiet $LocalStackImage
-    & $containerRunner run --detach --name localstack --publish "${LocalStackPort}:${LocalStackPort}" $LocalStackImage
-    $env:AWS_SERVICE_URL = "http://localhost:$LocalStackPort"
+    & $containerRunner pull --quiet $FlociImage
+    & $containerRunner run --detach --name floci --publish "${FlociPort}:${FlociPort}" $FlociImage
+    $env:AWS_SERVICE_URL = "http://localhost:$FlociPort"
 }
 
 if (-Not $SkipTests) {

--- a/src/JustSaying/Messaging/Channels/Receive/IMessageReceivePauseSignal.cs
+++ b/src/JustSaying/Messaging/Channels/Receive/IMessageReceivePauseSignal.cs
@@ -8,6 +8,12 @@ public interface IMessageReceivePauseSignal
     /// <summary>
     /// Sets status to pause receiving
     /// </summary>
+    /// <remarks>
+    /// Pausing cancels any in-flight <c>ReceiveMessage</c> call. Messages that SQS was in the
+    /// process of serving to that call may remain invisible until their visibility timeout
+    /// expires, so occasionally a message is delayed rather than being immediately received
+    /// by another consumer.
+    /// </remarks>
     void Pause();
 
     /// <summary>

--- a/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
+++ b/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
@@ -132,13 +132,14 @@ internal class MessageReceiveBuffer : IMessageReceiveBuffer
 
         try
         {
+            using var pauseCts = new CancellationTokenSource();
             using var linkedCts =
-                CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, receiveTimeout.Token);
+                CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, receiveTimeout.Token, pauseCts.Token);
             using var receiveCompleted = new CancellationTokenSource();
 
             Task pauseWatcher = _messageReceivePauseSignal is null
                 ? null
-                : CancelWhenPausedAsync(linkedCts, receiveCompleted.Token);
+                : CancelWhenPausedAsync(pauseCts, receiveCompleted.Token);
 
             try
             {
@@ -158,6 +159,13 @@ internal class MessageReceiveBuffer : IMessageReceiveBuffer
                                 .ConfigureAwait(false),
                         linkedCts.Token)
                     .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (pauseCts.IsCancellationRequested && !stoppingToken.IsCancellationRequested)
+            {
+                // The receive call was cancelled by the pause signal, and the receive middleware let the
+                // cancellation propagate. Swallow it so the buffer stays alive to resume later; shutdown
+                // and read timeout cancellations keep their existing behaviour.
+                messages = null;
             }
             finally
             {

--- a/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
+++ b/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
@@ -134,23 +134,39 @@ internal class MessageReceiveBuffer : IMessageReceiveBuffer
         {
             using var linkedCts =
                 CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, receiveTimeout.Token);
+            using var receiveCompleted = new CancellationTokenSource();
 
-            var context = new ReceiveMessagesContext
+            Task pauseWatcher = _messageReceivePauseSignal is null
+                ? null
+                : CancelWhenPausedAsync(linkedCts, receiveCompleted.Token);
+
+            try
             {
-                Count = count,
-                QueueName = _sqsQueueReader.QueueName,
-                RegionName = _sqsQueueReader.RegionSystemName,
-            };
+                var context = new ReceiveMessagesContext
+                {
+                    Count = count,
+                    QueueName = _sqsQueueReader.QueueName,
+                    RegionName = _sqsQueueReader.RegionSystemName,
+                };
 
-            _requestMessageAttributeNames.Add("content");
+                _requestMessageAttributeNames.Add("content");
 
-            messages = await _sqsMiddleware.RunAsync(context,
-                    async ct =>
-                        await _sqsQueueReader
-                            .GetMessagesAsync(count, _sqsWaitTime, _requestMessageAttributeNames.ToList(), ct)
-                            .ConfigureAwait(false),
-                    linkedCts.Token)
-                .ConfigureAwait(false);
+                messages = await _sqsMiddleware.RunAsync(context,
+                        async ct =>
+                            await _sqsQueueReader
+                                .GetMessagesAsync(count, _sqsWaitTime, _requestMessageAttributeNames.ToList(), ct)
+                                .ConfigureAwait(false),
+                        linkedCts.Token)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                if (pauseWatcher is not null)
+                {
+                    receiveCompleted.Cancel();
+                    await pauseWatcher.ConfigureAwait(false);
+                }
+            }
         }
         finally
         {
@@ -164,6 +180,37 @@ internal class MessageReceiveBuffer : IMessageReceiveBuffer
         }
 
         return messages;
+    }
+
+    /// <summary>
+    /// Cancels an in-flight receive call when the pause signal is paused, so that pausing takes effect
+    /// immediately rather than once the current long poll completes. <see cref="IMessageReceivePauseSignal"/>
+    /// has no change notification, so the signal is polled while the receive call is in flight.
+    /// </summary>
+    private async Task CancelWhenPausedAsync(CancellationTokenSource receiveCancellation, CancellationToken receiveCompleted)
+    {
+        try
+        {
+            while (!receiveCompleted.IsCancellationRequested)
+            {
+                if (_messageReceivePauseSignal.IsPaused)
+                {
+                    _logger.LogInformation(
+                        "Receiving messages was paused, cancelling in-flight receive call for queue '{QueueName}' in region '{Region}'.",
+                        _sqsQueueReader.QueueName,
+                        _sqsQueueReader.RegionSystemName);
+
+                    receiveCancellation.Cancel();
+                    return;
+                }
+
+                await Task.Delay(PauseReceivingBusyWaitDelay, receiveCompleted).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The receive call completed before the pause signal was paused
+        }
     }
 
     public InterrogationResult Interrogate()

--- a/tests/JustSaying.Extensions.DependencyInjection.StructureMap.Tests/StructureMapTests.cs
+++ b/tests/JustSaying.Extensions.DependencyInjection.StructureMap.Tests/StructureMapTests.cs
@@ -40,7 +40,12 @@ public class WhenUsingStructureMap(ITestOutputHelper outputHelper)
                                     .WithServiceUri(TestEnvironment.SimulatorUrl))
                             .Messaging((options) => options.WithRegion("eu-west-1"))
                             .Publications((options) => options.WithQueue<SimpleMessage>())
-                            .Subscriptions((options) => options.ForQueue<SimpleMessage>());
+                            .Subscriptions((options) => options.ForQueue<SimpleMessage>(
+                                // A message published while the simulator is serving an in-flight long poll can be
+                                // marked in-flight without being delivered, and is then only redelivered once the
+                                // visibility timeout expires; keep it short so that happens within the assertion window
+                                (queue) => queue.WithReadConfiguration(
+                                    (read) => read.WithVisibilityTimeout(TimeSpan.FromSeconds(2)))));
                     });
             });
 

--- a/tests/JustSaying.IntegrationTests/docker-compose.yml
+++ b/tests/JustSaying.IntegrationTests/docker-compose.yml
@@ -1,10 +1,8 @@
 version: "2"
 services:
-  localstack:
-    container_name: localstack
+  floci:
+    container_name: floci
     restart: unless-stopped
-    image: localstack/localstack:3.5.0
+    image: floci/floci:1.6.0
     ports:
       - 4566:4566
-    environment:
-      LS_LOG: debug

--- a/tests/JustSaying.UnitTests/Messaging/Channels/MessageReceiveBufferTests/WhenPausedDuringLongPoll.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/MessageReceiveBufferTests/WhenPausedDuringLongPoll.cs
@@ -1,0 +1,118 @@
+using Amazon.SQS.Model;
+using JustSaying.Messaging.Channels.Receive;
+using JustSaying.Messaging.Middleware;
+using JustSaying.Messaging.Middleware.Receive;
+using JustSaying.TestingFramework;
+using JustSaying.UnitTests.Messaging.Channels.SubscriptionGroupTests;
+using Microsoft.Extensions.Logging;
+
+namespace JustSaying.UnitTests.Messaging.Channels.MessageReceiveBufferTests;
+
+public class WhenPausedDuringLongPoll
+{
+    private class TestMessage : Message { }
+
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    private readonly TaskCompletionSource<bool> _receiveStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _receiveCancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly MessageReceivePauseSignal _messageReceivePauseSignal;
+    private readonly MessageReceiveBuffer _messageReceiveBuffer;
+
+    public WhenPausedDuringLongPoll(ITestOutputHelper testOutputHelper)
+    {
+        var loggerFactory = testOutputHelper.ToLoggerFactory();
+
+        MiddlewareBase<ReceiveMessagesContext, IList<Message>> sqsMiddleware =
+            new DefaultReceiveMessagesMiddleware(loggerFactory.CreateLogger<DefaultReceiveMessagesMiddleware>());
+
+        var messages = new List<Message> { new TestMessage() };
+        var queue = new FakeSqsQueue(async ct =>
+        {
+            _receiveStarted.TrySetResult(true);
+
+            // The first receive long polls until it is cancelled; once that has
+            // happened, subsequent receives return messages immediately
+            if (!_receiveCancelled.Task.IsCompleted)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(20), ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    _receiveCancelled.TrySetResult(true);
+                    throw;
+                }
+            }
+
+            return messages.AsEnumerable();
+        });
+
+        _messageReceivePauseSignal = new MessageReceivePauseSignal();
+
+        var monitor = new TrackingLoggingMonitor(
+            loggerFactory.CreateLogger<TrackingLoggingMonitor>());
+
+        _messageReceiveBuffer = new MessageReceiveBuffer(
+            10,
+            10,
+            TimeSpan.FromMinutes(5),
+            TimeSpan.FromSeconds(20),
+            queue,
+            sqsMiddleware,
+            _messageReceivePauseSignal,
+            monitor,
+            loggerFactory.CreateLogger<IMessageReceiveBuffer>());
+    }
+
+    [Fact]
+    public async Task Then_The_In_Flight_Receive_Call_Is_Cancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        var _ = _messageReceiveBuffer.RunAsync(cts.Token);
+
+        // Wait until a receive call is in flight, then pause
+        (await Task.WhenAny(_receiveStarted.Task, Task.Delay(Timeout))).ShouldBe(_receiveStarted.Task);
+        _messageReceivePauseSignal.Pause();
+
+        // The in-flight receive call should be cancelled promptly, rather than
+        // running for the full wait time
+        (await Task.WhenAny(_receiveCancelled.Task, Task.Delay(Timeout))).ShouldBe(_receiveCancelled.Task);
+
+        // Nothing should have been buffered
+        _messageReceiveBuffer.Reader.TryRead(out var _).ShouldBeFalse();
+
+        cts.Cancel();
+        await _messageReceiveBuffer.Reader.Completion;
+    }
+
+    [Fact]
+    public async Task Then_Messages_Flow_Again_After_Resuming()
+    {
+        using var cts = new CancellationTokenSource();
+        var _ = _messageReceiveBuffer.RunAsync(cts.Token);
+
+        // Wait until a receive call is in flight, then pause
+        (await Task.WhenAny(_receiveStarted.Task, Task.Delay(Timeout))).ShouldBe(_receiveStarted.Task);
+        _messageReceivePauseSignal.Pause();
+
+        (await Task.WhenAny(_receiveCancelled.Task, Task.Delay(Timeout))).ShouldBe(_receiveCancelled.Task);
+
+        _messageReceivePauseSignal.Resume();
+
+        using var readTimeout = new CancellationTokenSource(Timeout);
+        var couldRead = await _messageReceiveBuffer.Reader.WaitToReadAsync(readTimeout.Token);
+        couldRead.ShouldBeTrue();
+
+        cts.Cancel();
+
+        // Drain any buffered messages so the channel can complete
+        while (await _messageReceiveBuffer.Reader.WaitToReadAsync())
+        {
+            _messageReceiveBuffer.Reader.TryRead(out var _);
+        }
+
+        await _messageReceiveBuffer.Reader.Completion;
+    }
+}

--- a/tests/JustSaying.UnitTests/Messaging/Channels/MessageReceiveBufferTests/WhenPausedDuringLongPollWithPassThroughMiddleware.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/MessageReceiveBufferTests/WhenPausedDuringLongPollWithPassThroughMiddleware.cs
@@ -1,0 +1,107 @@
+using Amazon.SQS.Model;
+using JustSaying.Messaging.Channels.Receive;
+using JustSaying.Messaging.Middleware;
+using JustSaying.Messaging.Middleware.Receive;
+using JustSaying.TestingFramework;
+using JustSaying.UnitTests.Messaging.Channels.SubscriptionGroupTests;
+using Microsoft.Extensions.Logging;
+
+namespace JustSaying.UnitTests.Messaging.Channels.MessageReceiveBufferTests;
+
+/// <summary>
+/// Custom middleware registered via <c>WithCustomMiddleware</c> replaces
+/// <see cref="DefaultReceiveMessagesMiddleware"/> entirely and may propagate the
+/// <see cref="OperationCanceledException"/> from a pause-cancelled receive call. The buffer
+/// must swallow that cancellation itself, or the channel completes and can never resume.
+/// </summary>
+public class WhenPausedDuringLongPollWithPassThroughMiddleware
+{
+    private class TestMessage : Message { }
+
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    private readonly TaskCompletionSource<bool> _receiveStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _receiveCancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly MessageReceivePauseSignal _messageReceivePauseSignal;
+    private readonly MessageReceiveBuffer _messageReceiveBuffer;
+
+    public WhenPausedDuringLongPollWithPassThroughMiddleware(ITestOutputHelper testOutputHelper)
+    {
+        var loggerFactory = testOutputHelper.ToLoggerFactory();
+
+        // Propagates all exceptions, including cancellation of the receive call
+        MiddlewareBase<ReceiveMessagesContext, IList<Message>> sqsMiddleware =
+            new DelegateMiddleware<ReceiveMessagesContext, IList<Message>>();
+
+        var messages = new List<Message> { new TestMessage() };
+        var queue = new FakeSqsQueue(async ct =>
+        {
+            _receiveStarted.TrySetResult(true);
+
+            // The first receive long polls until it is cancelled; once that has
+            // happened, subsequent receives return messages immediately
+            if (!_receiveCancelled.Task.IsCompleted)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(20), ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    _receiveCancelled.TrySetResult(true);
+                    throw;
+                }
+            }
+
+            return messages.AsEnumerable();
+        });
+
+        _messageReceivePauseSignal = new MessageReceivePauseSignal();
+
+        var monitor = new TrackingLoggingMonitor(
+            loggerFactory.CreateLogger<TrackingLoggingMonitor>());
+
+        _messageReceiveBuffer = new MessageReceiveBuffer(
+            10,
+            10,
+            TimeSpan.FromMinutes(5),
+            TimeSpan.FromSeconds(20),
+            queue,
+            sqsMiddleware,
+            _messageReceivePauseSignal,
+            monitor,
+            loggerFactory.CreateLogger<IMessageReceiveBuffer>());
+    }
+
+    [Fact]
+    public async Task Then_The_Buffer_Survives_And_Messages_Flow_Again_After_Resuming()
+    {
+        using var cts = new CancellationTokenSource();
+        var _ = _messageReceiveBuffer.RunAsync(cts.Token);
+
+        // Wait until a receive call is in flight, then pause
+        (await Task.WhenAny(_receiveStarted.Task, Task.Delay(Timeout))).ShouldBe(_receiveStarted.Task);
+        _messageReceivePauseSignal.Pause();
+
+        (await Task.WhenAny(_receiveCancelled.Task, Task.Delay(Timeout))).ShouldBe(_receiveCancelled.Task);
+
+        // The propagated cancellation must not have completed the channel
+        _messageReceiveBuffer.Reader.Completion.IsCompleted.ShouldBeFalse();
+
+        _messageReceivePauseSignal.Resume();
+
+        using var readTimeout = new CancellationTokenSource(Timeout);
+        var couldRead = await _messageReceiveBuffer.Reader.WaitToReadAsync(readTimeout.Token);
+        couldRead.ShouldBeTrue();
+
+        cts.Cancel();
+
+        // Drain any buffered messages so the channel can complete
+        while (await _messageReceiveBuffer.Reader.WaitToReadAsync())
+        {
+            _messageReceiveBuffer.Reader.TryRead(out var _);
+        }
+
+        await _messageReceiveBuffer.Reader.Completion;
+    }
+}


### PR DESCRIPTION
Fixes #2287.

`Pause()` now cancels the in-flight `ReceiveMessage` call, rather than letting it carry on listening for up to `ReceiveMessagesWaitTime` (20s by default) and buffering whatever it returns. `MessageReceiveBuffer` watches `IsPaused` while a receive is in flight and cancels via a linked token when it flips — no public surface change, so custom `IMessageReceivePauseSignal` implementations get this for free.

One behaviour to note (now called out in the XML docs on `Pause()`): cancelling a `ReceiveMessage` that SQS is mid-way through serving can leave those messages invisible until the visibility timeout expires, so occasionally a message is delayed rather than instantly picked up by another consumer. I think that's the right trade for a signal whose job is "stop receiving now".

On versioning: nothing to change in the repo — MinVer already computes `7.4.1` for commits above the `v7.4.0` tag (this branch builds as `7.4.1-alpha.0.1`), so tagging `v7.4.1` once this is merged will do the trick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)