### PR TITLE
Cancel in-flight receive call when paused

### DIFF
--- a/src/JustSaying/Messaging/Channels/Receive/IMessageReceivePauseSignal.cs
+++ b/src/JustSaying/Messaging/Channels/Receive/IMessageReceivePauseSignal.cs
@@ -8,6 +8,12 @@ public interface IMessageReceivePauseSignal
     /// <summary>
     /// Sets status to pause receiving
     /// </summary>
+    /// <remarks>
+    /// Pausing cancels any in-flight <c>ReceiveMessage</c> call. Messages that SQS was in the
+    /// process of serving to that call may remain invisible until their visibility timeout
+    /// expires, so occasionally a message is delayed rather than being immediately received
+    /// by another consumer.
+    /// </remarks>
     void Pause();
 
     /// <summary>

--- a/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
+++ b/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
@@ -147,23 +147,47 @@ internal class MessageReceiveBuffer : IMessageReceiveBuffer
 
         try
         {
+            using var pauseCts = new CancellationTokenSource();
             using var linkedCts =
-                CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, receiveTimeout.Token);
+                CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, receiveTimeout.Token, pauseCts.Token);
+            using var receiveCompleted = new CancellationTokenSource();
 
-            var context = new ReceiveMessagesContext
+            Task pauseWatcher = _messageReceivePauseSignal is null
+                ? null
+                : CancelWhenPausedAsync(pauseCts, receiveCompleted.Token);
+
+            try
             {
-                Count = count,
-                QueueName = _sqsQueueReader.QueueName,
-                RegionName = _sqsQueueReader.RegionSystemName,
-            };
+                var context = new ReceiveMessagesContext
+                {
+                    Count = count,
+                    QueueName = _sqsQueueReader.QueueName,
+                    RegionName = _sqsQueueReader.RegionSystemName,
+                };
 
-            messages = await _sqsMiddleware.RunAsync(context,
-                    async ct =>
-                        await _sqsQueueReader
-                            .GetMessagesAsync(count, _sqsWaitTime, _requestMessageAttributeNames.ToList(), ct)
-                            .ConfigureAwait(false),
-                    linkedCts.Token)
-                .ConfigureAwait(false);
+                messages = await _sqsMiddleware.RunAsync(context,
+                        async ct =>
+                            await _sqsQueueReader
+                                .GetMessagesAsync(count, _sqsWaitTime, _requestMessageAttributeNames.ToList(), ct)
+                                .ConfigureAwait(false),
+                        linkedCts.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (pauseCts.IsCancellationRequested && !stoppingToken.IsCancellationRequested)
+            {
+                // The receive call was cancelled by the pause signal, and the receive middleware let the
+                // cancellation propagate. Swallow it so the buffer stays alive to resume later; shutdown
+                // and read timeout cancellations keep their existing behaviour.
+                messages = null;
+            }
+            finally
+            {
+                if (pauseWatcher is not null)
+                {
+                    receiveCompleted.Cancel();
+                    await pauseWatcher.ConfigureAwait(false);
+                }
+            }
         }
         finally
         {
@@ -177,6 +201,37 @@ internal class MessageReceiveBuffer : IMessageReceiveBuffer
         }
 
         return messages;
+    }
+
+    /// <summary>
+    /// Cancels an in-flight receive call when the pause signal is paused, so that pausing takes effect
+    /// immediately rather than once the current long poll completes. <see cref="IMessageReceivePauseSignal"/>
+    /// has no change notification, so the signal is polled while the receive call is in flight.
+    /// </summary>
+    private async Task CancelWhenPausedAsync(CancellationTokenSource receiveCancellation, CancellationToken receiveCompleted)
+    {
+        try
+        {
+            while (!receiveCompleted.IsCancellationRequested)
+            {
+                if (_messageReceivePauseSignal.IsPaused)
+                {
+                    _logger.LogInformation(
+                        "Receiving messages was paused, cancelling in-flight receive call for queue '{QueueName}' in region '{Region}'.",
+                        _sqsQueueReader.QueueName,
+                        _sqsQueueReader.RegionSystemName);
+
+                    receiveCancellation.Cancel();
+                    return;
+                }
+
+                await Task.Delay(PauseReceivingBusyWaitDelay, receiveCompleted).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The receive call completed before the pause signal was paused
+        }
     }
 
     public InterrogationResult Interrogate()

--- a/tests/JustSaying.IntegrationTests/docker-compose.yml
+++ b/tests/JustSaying.IntegrationTests/docker-compose.yml
@@ -1,9 +1,7 @@
 services:
-  localstack:
-    container_name: localstack
+  floci:
+    container_name: floci
     restart: unless-stopped
-    image: localstack/localstack:3.7
+    image: floci/floci:1.6.0
     ports:
       - "4566:4566"
-    environment:
-      LS_LOG: debug

--- a/tests/JustSaying.UnitTests/Messaging/Channels/MessageReceiveBufferTests/WhenPausedDuringLongPoll.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/MessageReceiveBufferTests/WhenPausedDuringLongPoll.cs
@@ -1,0 +1,128 @@
+using Amazon.SQS.Model;
+using JustSaying.Messaging;
+using JustSaying.Messaging.Channels.Receive;
+using JustSaying.Messaging.Channels.SubscriptionGroups;
+using JustSaying.Messaging.Compression;
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Middleware;
+using JustSaying.Messaging.Middleware.Receive;
+using JustSaying.TestingFramework;
+using JustSaying.UnitTests.Messaging.Channels.SubscriptionGroupTests;
+using Microsoft.Extensions.Logging;
+
+namespace JustSaying.UnitTests.Messaging.Channels.MessageReceiveBufferTests;
+
+public class WhenPausedDuringLongPoll
+{
+    private class TestMessage : Message { }
+
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    private readonly TaskCompletionSource<bool> _receiveStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _receiveCancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly MessageReceivePauseSignal _messageReceivePauseSignal;
+    private readonly MessageReceiveBuffer _messageReceiveBuffer;
+
+    public WhenPausedDuringLongPoll(ITestOutputHelper testOutputHelper)
+    {
+        var loggerFactory = testOutputHelper.ToLoggerFactory();
+
+        MiddlewareBase<ReceiveMessagesContext, IList<Message>> sqsMiddleware =
+            new DefaultReceiveMessagesMiddleware(loggerFactory.CreateLogger<DefaultReceiveMessagesMiddleware>());
+
+        var messages = new List<Message> { new TestMessage() };
+        var queue = new FakeSqsQueue(async ct =>
+        {
+            _receiveStarted.TrySetResult(true);
+
+            // The first receive long polls until it is cancelled; once that has
+            // happened, subsequent receives return messages immediately
+            if (!_receiveCancelled.Task.IsCompleted)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(20), ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    _receiveCancelled.TrySetResult(true);
+                    throw;
+                }
+            }
+
+            return messages.AsEnumerable();
+        });
+
+        var source = new SqsSource
+        {
+            SqsQueue = queue,
+            MessageConverter = new InboundMessageConverter(SimpleMessage.Serializer, new MessageCompressionRegistry(), false)
+        };
+
+        _messageReceivePauseSignal = new MessageReceivePauseSignal();
+
+        var monitor = new TrackingLoggingMonitor(
+            loggerFactory.CreateLogger<TrackingLoggingMonitor>());
+
+        _messageReceiveBuffer = new MessageReceiveBuffer(
+            10,
+            10,
+            TimeSpan.FromMinutes(5),
+            TimeSpan.FromSeconds(20),
+            source,
+            sqsMiddleware,
+            _messageReceivePauseSignal,
+            monitor,
+            loggerFactory.CreateLogger<IMessageReceiveBuffer>());
+    }
+
+    [Fact]
+    public async Task Then_The_In_Flight_Receive_Call_Is_Cancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        var _ = _messageReceiveBuffer.RunAsync(cts.Token);
+
+        // Wait until a receive call is in flight, then pause
+        (await Task.WhenAny(_receiveStarted.Task, Task.Delay(Timeout))).ShouldBe(_receiveStarted.Task);
+        _messageReceivePauseSignal.Pause();
+
+        // The in-flight receive call should be cancelled promptly, rather than
+        // running for the full wait time
+        (await Task.WhenAny(_receiveCancelled.Task, Task.Delay(Timeout))).ShouldBe(_receiveCancelled.Task);
+
+        // Nothing should have been buffered
+        _messageReceiveBuffer.Reader.TryRead(out var _).ShouldBeFalse();
+
+        await cts.CancelAsync();
+        await _messageReceiveBuffer.Reader.Completion;
+    }
+
+    [Fact]
+    public async Task Then_Messages_Flow_Again_After_Resuming()
+    {
+        using var cts = new CancellationTokenSource();
+        var _ = _messageReceiveBuffer.RunAsync(cts.Token);
+
+        // Wait until a receive call is in flight, then pause
+        (await Task.WhenAny(_receiveStarted.Task, Task.Delay(Timeout))).ShouldBe(_receiveStarted.Task);
+        _messageReceivePauseSignal.Pause();
+
+        (await Task.WhenAny(_receiveCancelled.Task, Task.Delay(Timeout))).ShouldBe(_receiveCancelled.Task);
+
+        _messageReceivePauseSignal.Resume();
+
+        using var readTimeout = new CancellationTokenSource(Timeout);
+        var couldRead = await _messageReceiveBuffer.Reader.WaitToReadAsync(readTimeout.Token);
+        couldRead.ShouldBeTrue();
+
+        await cts.CancelAsync();
+
+        // Drain any buffered messages so the channel can complete
+        while (await _messageReceiveBuffer.Reader.WaitToReadAsync())
+        {
+            _messageReceiveBuffer.Reader.TryRead(out var _);
+        }
+
+        await _messageReceiveBuffer.Reader.Completion;
+    }
+}

--- a/tests/JustSaying.UnitTests/Messaging/Channels/MessageReceiveBufferTests/WhenPausedDuringLongPollWithPassThroughMiddleware.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/MessageReceiveBufferTests/WhenPausedDuringLongPollWithPassThroughMiddleware.cs
@@ -1,0 +1,117 @@
+using Amazon.SQS.Model;
+using JustSaying.Messaging;
+using JustSaying.Messaging.Channels.Receive;
+using JustSaying.Messaging.Channels.SubscriptionGroups;
+using JustSaying.Messaging.Compression;
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Middleware;
+using JustSaying.Messaging.Middleware.Receive;
+using JustSaying.TestingFramework;
+using JustSaying.UnitTests.Messaging.Channels.SubscriptionGroupTests;
+using Microsoft.Extensions.Logging;
+
+namespace JustSaying.UnitTests.Messaging.Channels.MessageReceiveBufferTests;
+
+/// <summary>
+/// Custom middleware registered via <c>WithCustomMiddleware</c> replaces
+/// <see cref="DefaultReceiveMessagesMiddleware"/> entirely and may propagate the
+/// <see cref="OperationCanceledException"/> from a pause-cancelled receive call. The buffer
+/// must swallow that cancellation itself, or the channel completes and can never resume.
+/// </summary>
+public class WhenPausedDuringLongPollWithPassThroughMiddleware
+{
+    private class TestMessage : Message { }
+
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    private readonly TaskCompletionSource<bool> _receiveStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _receiveCancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly MessageReceivePauseSignal _messageReceivePauseSignal;
+    private readonly MessageReceiveBuffer _messageReceiveBuffer;
+
+    public WhenPausedDuringLongPollWithPassThroughMiddleware(ITestOutputHelper testOutputHelper)
+    {
+        var loggerFactory = testOutputHelper.ToLoggerFactory();
+
+        // Propagates all exceptions, including cancellation of the receive call
+        MiddlewareBase<ReceiveMessagesContext, IList<Message>> sqsMiddleware =
+            new DelegateMiddleware<ReceiveMessagesContext, IList<Message>>();
+
+        var messages = new List<Message> { new TestMessage() };
+        var queue = new FakeSqsQueue(async ct =>
+        {
+            _receiveStarted.TrySetResult(true);
+
+            // The first receive long polls until it is cancelled; once that has
+            // happened, subsequent receives return messages immediately
+            if (!_receiveCancelled.Task.IsCompleted)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(20), ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    _receiveCancelled.TrySetResult(true);
+                    throw;
+                }
+            }
+
+            return messages.AsEnumerable();
+        });
+
+        var source = new SqsSource
+        {
+            SqsQueue = queue,
+            MessageConverter = new InboundMessageConverter(SimpleMessage.Serializer, new MessageCompressionRegistry(), false)
+        };
+
+        _messageReceivePauseSignal = new MessageReceivePauseSignal();
+
+        var monitor = new TrackingLoggingMonitor(
+            loggerFactory.CreateLogger<TrackingLoggingMonitor>());
+
+        _messageReceiveBuffer = new MessageReceiveBuffer(
+            10,
+            10,
+            TimeSpan.FromMinutes(5),
+            TimeSpan.FromSeconds(20),
+            source,
+            sqsMiddleware,
+            _messageReceivePauseSignal,
+            monitor,
+            loggerFactory.CreateLogger<IMessageReceiveBuffer>());
+    }
+
+    [Fact]
+    public async Task Then_The_Buffer_Survives_And_Messages_Flow_Again_After_Resuming()
+    {
+        using var cts = new CancellationTokenSource();
+        var _ = _messageReceiveBuffer.RunAsync(cts.Token);
+
+        // Wait until a receive call is in flight, then pause
+        (await Task.WhenAny(_receiveStarted.Task, Task.Delay(Timeout))).ShouldBe(_receiveStarted.Task);
+        _messageReceivePauseSignal.Pause();
+
+        (await Task.WhenAny(_receiveCancelled.Task, Task.Delay(Timeout))).ShouldBe(_receiveCancelled.Task);
+
+        // The propagated cancellation must not have completed the channel
+        _messageReceiveBuffer.Reader.Completion.IsCompleted.ShouldBeFalse();
+
+        _messageReceivePauseSignal.Resume();
+
+        using var readTimeout = new CancellationTokenSource(Timeout);
+        var couldRead = await _messageReceiveBuffer.Reader.WaitToReadAsync(readTimeout.Token);
+        couldRead.ShouldBeTrue();
+
+        await cts.CancelAsync();
+
+        // Drain any buffered messages so the channel can complete
+        while (await _messageReceiveBuffer.Reader.WaitToReadAsync())
+        {
+            _messageReceiveBuffer.Reader.TryRead(out var _);
+        }
+
+        await _messageReceiveBuffer.Reader.Completion;
+    }
+}


### PR DESCRIPTION
Backport of #2288 to the v8 line. Fixes #2287 for v8 as well.

I've cut `maintenance/v8` from the `v8.1.0` tag for this, same as `maintenance/v7` sits at `v7.4.0` — `main` is a long way past `v8.1.0` now and has real features on it, so that's 8.2.0 material rather than a patch.

The fix is the same as on v7: `Pause()` now cancels the in-flight `ReceiveMessage` call rather than letting it carry on listening for up to `ReceiveMessagesWaitTime` (20s by default) and buffering whatever comes back. The cancellation is contained inside `MessageReceiveBuffer` via a dedicated pause token, so custom receive middleware that propagates the `OperationCanceledException` doesn't complete the channel and kill the subscription. No public surface change.

It didn't cherry-pick cleanly — v8's `MessageReceiveBuffer` takes an `SqsSource` rather than an `ISqsQueue` and has the diagnostics block in `RunAsync` — so I applied it by hand and ported both test classes to the v8 API. The one v7-only line (`_requestMessageAttributeNames.Add("content")`) doesn't exist here.

Same behaviour caveat as v7, and it's on the `Pause()` XML docs: cancelling a `ReceiveMessage` that SQS is mid-way through serving can leave those messages invisible until the visibility timeout expires, so occasionally a message is delayed rather than being picked up straight away by another consumer. Still feels like the right trade for a signal whose whole job is \"stop receiving now\".

Also brought across the floci switch from that PR, though only the `docker-compose.yml` half applies — there's no container setup in `build.ps1` on this branch. The visibility timeout change doesn't apply either, the StructureMap test uses the in-memory `LocalSqsSnsMessaging` bus here rather than a simulator. Integration suite is green against floci locally: 94 passed, 10 skipped, the usual simulator-related ones.

On versioning there's nothing to change in the repo — MinVer already computes `8.1.1` above the `v8.1.0` tag (this branch packs as `8.1.1-alpha.0.1`), so tagging `v8.1.1` once this is merged should do the trick.

One thing worth a look: `build.yml` only triggers on PRs into `main`/`dotnet-vnext`, so this PR won't get any CI — same gap `maintenance/v7` has. Tag pushes do match `v*` so the release itself will build fine. Happy to add `maintenance/*` to the PR trigger here if you'd rather have checks on these 🙂

🤖 Generated with [Claude Code](https://claude.com/claude-code)