### PR TITLE
Update OpenTelemetry packages to 1.15.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.5" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" Condition=" '$(TargetFramework)' == 'net462' " />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageVersion Include="StructureMap" Version="4.6.0" />
@@ -22,8 +22,8 @@
   <ItemGroup Label="Aspire">
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
@@ -52,7 +52,7 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Polly.Core" Version="8.6.6" />
     <PackageVersion Include="ReportGenerator" Version="5.5.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.13.0" />


### PR DESCRIPTION
Restore fails on `maintenance/v8` as it stands — `OpenTelemetry.Api` `1.15.0` picked up a moderate severity advisory ([GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j), excessive memory allocation parsing propagation headers) and NuGet audit warnings are errors here, so `NU1902` fails the pack step on all three OSes. Nothing to do with the 8.1.1 fix, it's just time catching up with the tag.

`1.15.3` is the first patched version, so I've bumped the four packages that have one:

- `OpenTelemetry.Api`
- `OpenTelemetry.Extensions.Hosting`
- `OpenTelemetry.Exporter.OpenTelemetryProtocol`
- `OpenTelemetry.Exporter.InMemory`

The `OpenTelemetry.Instrumentation.*` packages aren't covered by the advisory and have no `1.15.3`, so they stay at `1.15.0`. Kept it to the patch bump rather than following `main` up to `1.17.0` — this is a maintenance branch and I'd rather not move the floor further than the advisory needs.

`./build.ps1` is green locally and restore is clean 🙂

🤖 Generated with [Claude Code](https://claude.com/claude-code)