### PR TITLE
Spike: SQS canary traffic split via PWM polling gate

### DIFF
--- a/spikes/CanaryPolling/Demo/Demo.csproj
+++ b/spikes/CanaryPolling/Demo/Demo.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <Nullable>disable</Nullable>
+    <RootNamespace>Demo</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\CanaryDemo.Shared.csproj" />
+    <!-- Build-order only: the demo launches SampleApp as separate processes. -->
+    <ProjectReference Include="..\SampleApp\SampleApp.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+  </ItemGroup>
+
+</Project>

--- a/spikes/CanaryPolling/Demo/Demo.csproj
+++ b/spikes/CanaryPolling/Demo/Demo.csproj
@@ -12,8 +12,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Shared\CanaryDemo.Shared.csproj" />
-    <!-- Build-order only: the demo launches SampleApp as separate processes. -->
+    <!-- Build-order only: the demo launches these as separate processes. -->
     <ProjectReference Include="..\SampleApp\SampleApp.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\SqsProxy\SqsProxy.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/spikes/CanaryPolling/Demo/PodProcess.cs
+++ b/spikes/CanaryPolling/Demo/PodProcess.cs
@@ -1,0 +1,105 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Demo;
+
+/// <summary>
+/// Launches one SampleApp instance as a real OS process (pods must not share state)
+/// and collects the cumulative handled-count it reports on stdout.
+/// </summary>
+public sealed class PodProcess : IDisposable
+{
+    private readonly Process _process;
+
+    public string Name { get; }
+    public string Pool { get; }
+    public long HandledCount => Interlocked.Read(ref _handledCount);
+    public long Casualties => Interlocked.Read(ref _casualties);
+    public long Delayed => Interlocked.Read(ref _delayed);
+    public long MaxLatencyMs => Interlocked.Read(ref _maxLatencyMs);
+    private long _handledCount;
+    private long _casualties;
+    private long _delayed;
+    private long _maxLatencyMs;
+
+    private PodProcess(string name, string pool, Process process)
+    {
+        Name = name;
+        Pool = pool;
+        _process = process;
+    }
+
+    public static PodProcess Start(string name, string pool, string sampleAppDll, IDictionary<string, string> environment)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"exec \"{sampleAppDll}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        foreach (var (key, value) in environment)
+        {
+            psi.Environment[key] = value;
+        }
+
+        psi.Environment["POD_NAME"] = name;
+        psi.Environment["POOL_NAME"] = pool;
+
+        var process = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to start pod {name}.");
+        var pod = new PodProcess(name, pool, process);
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is not null && Environment.GetEnvironmentVariable("DEMO_DEBUG") is not null)
+            {
+                Console.WriteLine($"  [{name}:out] {e.Data}");
+            }
+
+            // "STAT <pool> <pod> <count> <casualties> <delayed> <maxLatencyMs>" (cumulative)
+            if (e.Data is not null && e.Data.StartsWith("STAT ", StringComparison.Ordinal))
+            {
+                var parts = e.Data.Split(' ');
+                if (parts.Length >= 7 && long.TryParse(parts[3], out long count))
+                {
+                    Interlocked.Exchange(ref pod._handledCount, count);
+                    if (long.TryParse(parts[4], out long casualties)) Interlocked.Exchange(ref pod._casualties, casualties);
+                    if (long.TryParse(parts[5], out long delayed)) Interlocked.Exchange(ref pod._delayed, delayed);
+                    if (long.TryParse(parts[6], out long maxMs)) Interlocked.Exchange(ref pod._maxLatencyMs, maxMs);
+                    Volatile.Write(ref pod._reported, true);
+                }
+            }
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (!string.IsNullOrWhiteSpace(e.Data))
+            {
+                Console.Error.WriteLine($"  [{name}] {e.Data}");
+            }
+        };
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        return pod;
+    }
+
+    /// <summary>True once the pod's stats loop is up, i.e. the app started successfully.</summary>
+    public bool HasReported => Volatile.Read(ref _reported);
+    private bool _reported;
+
+    public void Dispose()
+    {
+        try
+        {
+            if (!_process.HasExited)
+            {
+                _process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        _process.Dispose();
+    }
+}

--- a/spikes/CanaryPolling/Demo/Program.cs
+++ b/spikes/CanaryPolling/Demo/Program.cs
@@ -1,0 +1,589 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Amazon;
+using Amazon.SQS;
+using CanaryDemo.Shared;
+using Demo;
+using JustSaying;
+using JustSaying.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+// Orchestrates the canary rollout demo. Everything in this project is demo/load
+// machinery; the interesting code — the PWM polling throttle — lives in SampleApp.
+//
+// Topology: 2 "primary" + 2 "canary" SampleApp processes, one shared SQS queue.
+// The rollout signal is a weights file the orchestrator writes and every pod watches:
+//   {"primary": 1.0, "canary": 0.33}
+//
+// Modes:
+//   dotnet run                     weight sweep on floci: canary 0.33 → 1.0 → 0.0 under steady load
+//   dotnet run -- --regimes        fixed 80/20 target validated across traffic regimes:
+//                                    backlog (queue backpressure, pods flat out)
+//                                    steady  (continuous arrivals, queue near-empty)
+//                                    idle    (sparse arrivals, all pods parked long-polling)
+//   dotnet run -- --longpoll       casualty validation: steady + idle at the recommended
+//                                    config, then churn (1s period stop/start) while
+//                                    measuring end-to-end latency — the gate should
+//                                    strand nothing ("casualties" = ~30s latency spikes)
+//   dotnet run -- --aws            use real AWS SQS via the default credential chain
+//                                  (queues are deleted afterwards); combine with a mode
+//   dotnet run -- --quick          shorter phases (noisier numbers)
+//   FLOCI_URL=http://...           use an already-running floci/SQS-compatible endpoint
+
+bool useAws = args.Contains("--aws");
+bool regimes = args.Contains("--regimes");
+bool longPoll = args.Contains("--longpoll");
+bool quick = args.Contains("--quick");
+
+// 2 canary pods at this weight vs 2 primary pods at 1.0 targets a 20% canary share.
+// The exact share the PWM model predicts differs slightly per regime (printed per
+// scenario); owning that mapping is rollout tooling's job in real life.
+const double CanaryWeight = 0.327;
+const int SteadyMessagesPerSecond = 30;
+
+const string ContainerName = "canary-demo-floci";
+string flociUrl = null;
+string accountId = null;
+string region;
+
+if (useAws)
+{
+    region = Environment.GetEnvironmentVariable("AWS_REGION")
+        ?? Environment.GetEnvironmentVariable("AWS_DEFAULT_REGION")
+        ?? (await RunProcessAsync("aws", "configure get region")).Trim();
+    if (string.IsNullOrWhiteSpace(region))
+    {
+        throw new InvalidOperationException("Could not determine an AWS region (AWS_REGION / aws configure get region).");
+    }
+
+    // The SDK's default chain can't read every CLI auth source (e.g. `aws login`),
+    // so borrow the CLI's short-lived credentials and put them in our environment;
+    // the SDK finds them there, and spawned pods inherit them.
+    if (Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID") is null)
+    {
+        var creds = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+            await RunProcessAsync("aws", "configure export-credentials"));
+        Environment.SetEnvironmentVariable("AWS_ACCESS_KEY_ID", creds["AccessKeyId"].GetString());
+        Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", creds["SecretAccessKey"].GetString());
+        if (creds.TryGetValue("SessionToken", out var token) && token.ValueKind == JsonValueKind.String)
+        {
+            Environment.SetEnvironmentVariable("AWS_SESSION_TOKEN", token.GetString());
+        }
+    }
+}
+else
+{
+    flociUrl = Environment.GetEnvironmentVariable("FLOCI_URL") ?? "http://localhost:4599";
+    accountId = RandomNumberGenerator.GetInt32(1_000_000_000).ToString("D9", CultureInfo.InvariantCulture) + "000";
+    region = "eu-west-1";
+}
+
+string runId = Guid.NewGuid().ToString("N")[..8];
+string queueName = $"canary-orders-{runId}";
+string weightsFile = Path.Combine(Path.GetTempPath(), $"canary-weights-{runId}.json");
+
+Console.WriteLine($"""
+    Canary rollout demo — PWM via the receive-middleware gate ({(longPoll ? "casualty validation" : regimes ? "traffic-regime validation" : "weight sweep")})
+    Backend: {(useAws ? $"AWS SQS ({region})" : $"floci ({flociUrl})")}
+    Queue: {queueName}
+    Signal file: {weightsFile}
+
+    """);
+
+if (!useAws)
+{
+    await EnsureFlociAsync();
+}
+
+void WriteWeights(double canaryWeight) =>
+    File.WriteAllText(weightsFile, JsonSerializer.Serialize(new Dictionary<string, double>
+    {
+        ["primary"] = 1.0,
+        ["canary"] = canaryWeight,
+    }));
+
+// The producer service: an ordinary JustSaying publisher (this also creates the queue).
+await using var producerServices = new ServiceCollection()
+    .AddLogging(lb => lb.AddConsole().SetMinimumLevel(LogLevel.Error))
+    .AddJustSaying((config, _) =>
+    {
+        config.Messaging(m => m.WithRegion(region));
+        if (!useAws)
+        {
+            config.Client(c => c.WithClientFactory(() => new FlociClientFactory(new Uri(flociUrl), accountId, region)));
+        }
+
+        config.Publications(p => p.WithQueue<CanaryOrder>(q => q.WithQueueName(queueName)));
+    })
+    .BuildServiceProvider();
+
+var publisher = producerServices.GetRequiredService<IMessagePublisher>();
+var batchPublisher = producerServices.GetRequiredService<IMessageBatchPublisher>();
+await publisher.StartAsync(CancellationToken.None);
+
+string sampleAppDll = LocateSampleAppDll();
+
+try
+{
+    if (longPoll)
+    {
+        await RunLongPollAsync();
+    }
+    else if (regimes)
+    {
+        await RunRegimesAsync();
+    }
+    else
+    {
+        await RunSweepAsync();
+    }
+}
+finally
+{
+    File.Delete(weightsFile);
+    if (useAws)
+    {
+        await DeleteQueuesAsync();
+    }
+}
+
+Console.WriteLine(useAws
+    ? "Done."
+    : $"Done. (The '{ContainerName}' container is left running for faster re-runs: docker rm -f {ContainerName})");
+
+// ---------------------------------------------------------------------------
+// Scenario sets
+// ---------------------------------------------------------------------------
+
+async Task RunSweepAsync()
+{
+    var phaseDuration = TimeSpan.FromSeconds(quick ? 15 : 30);
+    (double Weight, double Target)[] phases = [(CanaryWeight, 0.20), (1.0, 0.50), (0.0, 0.00)];
+
+    WriteWeights(phases[0].Weight);
+    var pods = await StartPodsAsync(PodEnv(pwmPeriodSeconds: 2, receiveWaitSeconds: 1, handlerWorkMs: 5));
+    try
+    {
+        foreach (var (weight, target) in phases)
+        {
+            WriteWeights(weight);
+            Console.WriteLine($"Canary weight → {weight:0.00} (signal file updated; steady load {SteadyMessagesPerSecond} msg/s for {phaseDuration.TotalSeconds:0}s)");
+
+            // Let pods pick up the file change and finish already-scheduled PWM pulses.
+            await Task.Delay(TimeSpan.FromSeconds(4));
+
+            var before = Snapshot(pods);
+            await PublishSteadyAsync(SteadyMessagesPerSecond, phaseDuration);
+            await Task.Delay(TimeSpan.FromSeconds(3)); // drain the tail
+
+            Report(pods, before, $"weight {weight:0.00}", target);
+            Console.WriteLine();
+        }
+    }
+    finally
+    {
+        DisposePods(pods);
+    }
+}
+
+async Task RunRegimesAsync()
+{
+    WriteWeights(CanaryWeight);
+
+    // --- Regime 1: backlog / backpressure. The queue is pre-loaded and pods run
+    // flat out, so processing capacity is the limit and the drain is elastic:
+    // modeled canary share = w/(w+1). Slower handlers (40ms) stretch the drain
+    // across many PWM periods (2s) so the duty cycle can average out.
+    // Sized so the drain spans ~10 PWM periods; a 1-2 period drain is too lumpy to average out.
+    int backlogCount = quick ? 2000 : 12_000;
+    Console.WriteLine($"Regime 1: backlog — pre-loading {backlogCount} messages, then starting pods (PWM period 2s, handler 40ms)");
+    await PublishBacklogAsync(backlogCount);
+
+    var pods = await StartPodsAsync(PodEnv(pwmPeriodSeconds: 2, receiveWaitSeconds: 1, handlerWorkMs: 40));
+    try
+    {
+        var before = Snapshot(pods); // zeros, but keeps reporting uniform
+        var sw = Stopwatch.StartNew();
+        await WaitUntilAsync(
+            () => Task.FromResult(Total(pods) >= backlogCount),
+            TimeSpan.FromMinutes(6),
+            "backlog did not drain in time");
+        Report(pods, before, $"backlog drained in {sw.Elapsed.TotalSeconds:0.0}s", Modeled: CanaryWeight / (CanaryWeight + 1));
+        Console.WriteLine();
+    }
+    finally
+    {
+        DisposePods(pods);
+    }
+
+    // --- Regimes 2 + 3 share a pod set: PWM period 10s with a 1s receive wait.
+    // The gate never cancels a poll, so the last poll of each on-window lingers up
+    // to the wait time into the off-window. Keeping wait << period bounds that
+    // distortion (and it only exists at all when the queue is idle).
+    pods = await StartPodsAsync(PodEnv(pwmPeriodSeconds: 10, receiveWaitSeconds: 1, handlerWorkMs: 5));
+    try
+    {
+        // Regime 2: steady arrivals, queue near-empty, pods mostly waiting.
+        var steadyDuration = TimeSpan.FromSeconds(quick ? 30 : 60);
+        Console.WriteLine($"Regime 2: steady — {SteadyMessagesPerSecond} msg/s for {steadyDuration.TotalSeconds:0}s (queue near-empty)");
+        var before = Snapshot(pods);
+        await PublishSteadyAsync(SteadyMessagesPerSecond, steadyDuration);
+        await Task.Delay(TimeSpan.FromSeconds(3));
+        Report(pods, before, "steady arrivals", Modeled: ShareWhenOpenFractionIs(CanaryWeight));
+        Console.WriteLine();
+
+        // Regime 3: sparse arrivals — one message every 2 seconds, so every pod is
+        // parked in an empty long poll when each message lands. This is the regime
+        // where the split hinges on how SQS picks among waiting receivers.
+        var idleDuration = TimeSpan.FromSeconds(quick ? 120 : 240);
+        Console.WriteLine($"Regime 3: idle — 1 msg every 2s for {idleDuration.TotalSeconds:0}s (all pods parked long-polling)");
+        before = Snapshot(pods);
+        await PublishSparseAsync(TimeSpan.FromSeconds(2), idleDuration, pods, before);
+        await Task.Delay(TimeSpan.FromSeconds(3));
+        Report(pods, before, "idle / sparse arrivals", Modeled: ShareWhenOpenFractionIs(CanaryWeight + 1d / 10d));
+        Console.WriteLine();
+    }
+    finally
+    {
+        DisposePods(pods);
+    }
+
+    // Expected canary share when each canary pod has an open receive for fraction p
+    // of the time and SQS picks uniformly among open receivers (2 canary, 2 primary):
+    // E[k/(k+2)] for k ~ Binomial(2, p). In the idle regime p gains ~wait/period of
+    // lingering receive per cycle.
+    static double ShareWhenOpenFractionIs(double p) => (2 * p * (1 - p)) / 3 + (p * p) / 2;
+}
+
+// Validates that the gate throttle never strands messages: casualties (a message caught
+// in an aborted delivery goes invisible until the ~30s visibility timeout) show up as
+// handled messages with ~30s end-to-end latency, and the gate should produce none.
+async Task RunLongPollAsync()
+{
+    WriteWeights(CanaryWeight);
+    double modeled = (2 * CanaryWeight * (1 - CanaryWeight)) / 3 + (CanaryWeight * CanaryWeight) / 2;
+
+    // --- Part 1: the recommended config — 10s PWM period, 1s receive wait (the gate
+    // never cancels a poll, so the wait must stay well under the period).
+    const double Part1Wait = 1;
+    Console.WriteLine($"Part 1: wait {Part1Wait:0}s, period 10s");
+    var pods = await StartPodsAsync(PodEnv(pwmPeriodSeconds: 10, receiveWaitSeconds: Part1Wait, handlerWorkMs: 5));
+    try
+    {
+        var steadyDuration = TimeSpan.FromSeconds(quick ? 30 : 60);
+        Console.WriteLine($"  steady {SteadyMessagesPerSecond} msg/s for {steadyDuration.TotalSeconds:0}s");
+        var before = Snapshot(pods);
+        await PublishSteadyAsync(SteadyMessagesPerSecond, steadyDuration);
+        await Task.Delay(TimeSpan.FromSeconds(3));
+        Report(pods, before, "steady", modeled);
+        Console.WriteLine();
+
+        var idleDuration = TimeSpan.FromSeconds(quick ? 120 : 240);
+        Console.WriteLine($"  idle — 1 msg every 2s for {idleDuration.TotalSeconds:0}s (the regime that used to collapse)");
+        before = Snapshot(pods);
+        await PublishSparseAsync(TimeSpan.FromSeconds(2), idleDuration, pods, before);
+        await Task.Delay(TimeSpan.FromSeconds(3));
+        Report(pods, before, "idle", modeled);
+        ReportLatency(pods);
+        Console.WriteLine();
+    }
+    finally
+    {
+        DisposePods(pods);
+    }
+
+    // --- Part 2: churn. A 1s PWM period with 20s waits means each canary cancels an
+    // in-flight receive roughly once a second, under load. The question: do messages
+    // that were mid-delivery when the call was cancelled become "casualties" — received
+    // (invisible) but unprocessed until the visibility timeout (30s) redelivers them?
+    // Casualties show up as handled messages with ~30s end-to-end latency.
+    var churnDuration = TimeSpan.FromSeconds(quick ? 60 : 120);
+    Console.WriteLine($"Part 2: churn — period 1s, steady {SteadyMessagesPerSecond} msg/s for {churnDuration.TotalSeconds:0}s");
+    pods = await StartPodsAsync(PodEnv(pwmPeriodSeconds: 1, receiveWaitSeconds: 1, handlerWorkMs: 5));
+    try
+    {
+        var before = Snapshot(pods);
+        int published = await PublishSteadyAsync(SteadyMessagesPerSecond, churnDuration);
+
+        // Let stragglers arrive: a casualty takes ~30s (visibility timeout) to come back.
+        Console.WriteLine($"  published {published}; waiting for the tail (casualties redeliver after ~30s)...");
+        var sw = Stopwatch.StartNew();
+        while (Total(pods) < published && sw.Elapsed < TimeSpan.FromSeconds(120))
+        {
+            await Task.Delay(1000);
+        }
+
+        Report(pods, before, $"churn ({Total(pods)}/{published} accounted for)", modeled);
+        ReportLatency(pods);
+        Console.WriteLine();
+    }
+    finally
+    {
+        DisposePods(pods);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Measurement + load helpers
+// ---------------------------------------------------------------------------
+
+static long Total(List<PodProcess> pods) => pods.Sum(p => p.HandledCount);
+
+static (long Primary, long Canary) Snapshot(List<PodProcess> pods) => (
+    pods.Where(p => p.Pool == "primary").Sum(p => p.HandledCount),
+    pods.Where(p => p.Pool == "canary").Sum(p => p.HandledCount));
+
+static void Report(List<PodProcess> pods, (long Primary, long Canary) before, string label, double Modeled)
+{
+    var after = Snapshot(pods);
+    long primary = after.Primary - before.Primary;
+    long canary = after.Canary - before.Canary;
+    long total = primary + canary;
+    double share = total == 0 ? 0 : canary / (double)total;
+    Console.WriteLine($"  {label,-40} primary={primary,5}  canary={canary,5}  canary share={share,7:P1}  (modeled {Modeled:P1})");
+    Console.WriteLine($"  per pod: {string.Join("  ", pods.Select(p => $"{p.Name}={p.HandledCount}"))}");
+}
+
+// Latency buckets are cumulative per pod set (pods are fresh per scenario part).
+static void ReportLatency(List<PodProcess> pods)
+{
+    long total = pods.Sum(p => p.HandledCount);
+    long casualties = pods.Sum(p => p.Casualties);
+    long delayed = pods.Sum(p => p.Delayed);
+    long maxMs = pods.Max(p => p.MaxLatencyMs);
+    double rate = total == 0 ? 0 : casualties / (double)total;
+    Console.WriteLine($"  latency: casualties (>15s, i.e. visibility-timeout redeliveries)={casualties} ({rate:P2} of {total}), delayed 5-15s={delayed}, max={maxMs / 1000.0:0.0}s");
+}
+
+async Task<int> PublishSteadyAsync(int perSecond, TimeSpan duration)
+{
+    using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(100));
+    int perTick = Math.Max(1, perSecond / 10);
+    int sequence = 0;
+    var sw = Stopwatch.StartNew();
+    while (sw.Elapsed < duration && await timer.WaitForNextTickAsync())
+    {
+        for (int i = 0; i < perTick; i++)
+        {
+            await publisher.PublishAsync(new CanaryOrder { Sequence = sequence++, PublishedAtUtc = DateTime.UtcNow });
+        }
+    }
+
+    return sequence;
+}
+
+async Task PublishSparseAsync(TimeSpan gap, TimeSpan duration, List<PodProcess> pods, (long Primary, long Canary) before)
+{
+    using var timer = new PeriodicTimer(gap);
+    int sequence = 0;
+    var sw = Stopwatch.StartNew();
+    var lastProgress = TimeSpan.Zero;
+    while (sw.Elapsed < duration && await timer.WaitForNextTickAsync())
+    {
+        await publisher.PublishAsync(new CanaryOrder { Sequence = sequence++, PublishedAtUtc = DateTime.UtcNow });
+
+        if (sw.Elapsed - lastProgress >= TimeSpan.FromSeconds(30))
+        {
+            lastProgress = sw.Elapsed;
+            var now = Snapshot(pods);
+            long p = now.Primary - before.Primary;
+            long c = now.Canary - before.Canary;
+            Console.WriteLine($"    t+{sw.Elapsed.TotalSeconds,3:0}s: {sequence} sent, primary={p} canary={c}");
+        }
+    }
+}
+
+async Task PublishBacklogAsync(int count)
+{
+    const int PerBatch = 10;   // one SQS SendMessageBatch per call
+    const int Concurrency = 16;
+    var sw = Stopwatch.StartNew();
+    for (int i = 0; i < count; i += PerBatch * Concurrency)
+    {
+        var calls = Enumerable.Range(0, Concurrency)
+            .Select(c => i + c * PerBatch)
+            .Where(start => start < count)
+            .Select(start => batchPublisher.PublishAsync(
+                Enumerable.Range(start, Math.Min(PerBatch, count - start))
+                    .Select(seq => (JustSaying.Models.Message)new CanaryOrder { Sequence = seq, PublishedAtUtc = DateTime.UtcNow })
+                    .ToList()));
+        await Task.WhenAll(calls);
+    }
+
+    Console.WriteLine($"  published {count} messages in {sw.Elapsed.TotalSeconds:0.0}s");
+}
+
+// ---------------------------------------------------------------------------
+// Pod + environment plumbing
+// ---------------------------------------------------------------------------
+
+Dictionary<string, string> PodEnv(double pwmPeriodSeconds, double receiveWaitSeconds, double handlerWorkMs)
+{
+    var env = new Dictionary<string, string>
+    {
+        ["AWS_REGION"] = region,
+        ["QUEUE_NAME"] = queueName,
+        ["WEIGHTS_FILE"] = weightsFile,
+        ["PWM_PERIOD_SECONDS"] = pwmPeriodSeconds.ToString(CultureInfo.InvariantCulture),
+        ["RECEIVE_WAIT_SECONDS"] = receiveWaitSeconds.ToString(CultureInfo.InvariantCulture),
+        ["HANDLER_WORK_MS"] = handlerWorkMs.ToString(CultureInfo.InvariantCulture),
+    };
+
+    if (Environment.GetEnvironmentVariable("DEMO_POD_LOG_LEVEL") is { } podLogLevel)
+    {
+        env["LOG_LEVEL"] = podLogLevel;
+    }
+
+    if (!useAws)
+    {
+        env["SQS_ENDPOINT"] = flociUrl;
+        env["AWS_ACCOUNT_ID"] = accountId;
+    }
+
+    return env;
+}
+
+async Task<List<PodProcess>> StartPodsAsync(Dictionary<string, string> environment)
+{
+    var pods = new List<PodProcess>();
+    foreach (var (name, pool) in new[] { ("primary-1", "primary"), ("primary-2", "primary"), ("canary-1", "canary"), ("canary-2", "canary") })
+    {
+        pods.Add(PodProcess.Start(name, pool, sampleAppDll, environment));
+    }
+
+    Console.WriteLine($"  started {pods.Count} pods, waiting for them to come up...");
+    try
+    {
+        await WaitUntilAsync(
+            () => Task.FromResult(pods.All(p => p.HasReported)),
+            TimeSpan.FromSeconds(90),
+            "pods did not start reporting");
+    }
+    catch
+    {
+        DisposePods(pods);
+        throw;
+    }
+
+    return pods;
+}
+
+static void DisposePods(List<PodProcess> pods)
+{
+    foreach (var pod in pods)
+    {
+        pod.Dispose();
+    }
+}
+
+async Task EnsureFlociAsync()
+{
+    using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+
+    if (await IsReachableAsync())
+    {
+        return;
+    }
+
+    if (Environment.GetEnvironmentVariable("FLOCI_URL") is not null)
+    {
+        throw new InvalidOperationException($"FLOCI_URL={flociUrl} is not reachable.");
+    }
+
+    Console.WriteLine($"No SQS endpoint at {flociUrl}; starting container '{ContainerName}'...");
+    await RunProcessAsync("docker", $"rm -f {ContainerName}", ignoreErrors: true);
+    await RunProcessAsync("docker", $"run -d --name {ContainerName} -p 4599:4566 floci/floci:latest");
+    await WaitUntilAsync(IsReachableAsync, TimeSpan.FromSeconds(30), $"floci did not become reachable at {flociUrl}");
+    Console.WriteLine();
+
+    async Task<bool> IsReachableAsync()
+    {
+        try
+        {
+            using var response = await http.GetAsync(flociUrl);
+            return true;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            return false;
+        }
+    }
+}
+
+async Task DeleteQueuesAsync()
+{
+    try
+    {
+        using var sqs = new AmazonSQSClient(RegionEndpoint.GetBySystemName(region));
+        var queues = await sqs.ListQueuesAsync(queueName); // prefix match catches the _error queue too
+        foreach (var url in queues.QueueUrls ?? [])
+        {
+            if (url.EndsWith("_error", StringComparison.Ordinal))
+            {
+                var attrs = await sqs.GetQueueAttributesAsync(url, ["ApproximateNumberOfMessages"]);
+                Console.WriteLine($"  error queue holds {attrs.ApproximateNumberOfMessages} message(s) — {(attrs.ApproximateNumberOfMessages == 0 ? "nothing dead-lettered" : "some messages were dead-lettered!")}");
+            }
+
+            await sqs.DeleteQueueAsync(url);
+            Console.WriteLine($"  deleted {url}");
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"  queue cleanup failed ({ex.Message}); delete queues with prefix '{queueName}' manually.");
+    }
+}
+
+static async Task<string> RunProcessAsync(string fileName, string arguments, bool ignoreErrors = false)
+{
+    var psi = new ProcessStartInfo(fileName, arguments)
+    {
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+    };
+    using var process = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to run {fileName}. Is it installed?");
+    string stdout = await process.StandardOutput.ReadToEndAsync();
+    string stderr = await process.StandardError.ReadToEndAsync();
+    await process.WaitForExitAsync();
+    if (!ignoreErrors && process.ExitCode != 0)
+    {
+        throw new InvalidOperationException($"{fileName} {arguments} failed: {stderr.Trim()}");
+    }
+
+    return stdout;
+}
+
+static async Task WaitUntilAsync(Func<Task<bool>> condition, TimeSpan timeout, string timeoutMessage)
+{
+    var sw = Stopwatch.StartNew();
+    while (sw.Elapsed < timeout)
+    {
+        if (await condition())
+        {
+            return;
+        }
+
+        await Task.Delay(500);
+    }
+
+    throw new TimeoutException(timeoutMessage);
+}
+
+string LocateSampleAppDll()
+{
+    // With the repo's UseArtifactsOutput layout, sibling project outputs live at
+    // artifacts/bin/<Project>/<configuration>/. Resolve SampleApp's relative to our own.
+    string baseDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+    string configuration = Path.GetFileName(baseDir);
+    string dll = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "SampleApp", configuration, "SampleApp.dll"));
+    if (!File.Exists(dll))
+    {
+        throw new FileNotFoundException($"SampleApp.dll not found at {dll}; build the SampleApp project first.");
+    }
+
+    return dll;
+}

--- a/spikes/CanaryPolling/Demo/Program.cs
+++ b/spikes/CanaryPolling/Demo/Program.cs
@@ -38,6 +38,18 @@ bool regimes = args.Contains("--regimes");
 bool longPoll = args.Contains("--longpoll");
 bool quick = args.Contains("--quick");
 
+// --proxy: shape traffic in an SQS-aware proxy between the pods and the queue (the
+// Istio/Envoy model) instead of inside the pods — pods run as completely vanilla
+// consumers (GATE_ENABLED=false) pointed at a per-pool proxy listener. floci-only:
+// an explicit (non-transparent) proxy in front of real AWS would need to re-sign
+// requests, because SigV4 covers the Host header (see README).
+bool proxyMode = args.Contains("--proxy");
+if (proxyMode && useAws)
+{
+    Console.Error.WriteLine("--proxy is floci-only: an explicit proxy breaks SigV4 against real AWS (Host header is signed). In Istio the interception is transparent, so the signature survives.");
+    return;
+}
+
 // 2 canary pods at this weight vs 2 primary pods at 1.0 targets a 20% canary share.
 // The exact share the PWM model predicts differs slightly per regime (printed per
 // scenario); owning that mapping is rollout tooling's job in real life.
@@ -86,7 +98,7 @@ string queueName = $"canary-orders-{runId}";
 string weightsFile = Path.Combine(Path.GetTempPath(), $"canary-weights-{runId}.json");
 
 Console.WriteLine($"""
-    Canary rollout demo — PWM via the receive-middleware gate ({(longPoll ? "casualty validation" : regimes ? "traffic-regime validation" : "weight sweep")})
+    Canary rollout demo — PWM via {(proxyMode ? "an SQS-aware proxy (the Istio model, pods unmodified)" : "the receive-middleware gate")} ({(longPoll ? "casualty validation" : regimes ? "traffic-regime validation" : "weight sweep")})
     Backend: {(useAws ? $"AWS SQS ({region})" : $"floci ({flociUrl})")}
     Queue: {queueName}
     Signal file: {weightsFile}
@@ -124,11 +136,15 @@ var publisher = producerServices.GetRequiredService<IMessagePublisher>();
 var batchPublisher = producerServices.GetRequiredService<IMessageBatchPublisher>();
 await publisher.StartAsync(CancellationToken.None);
 
-string sampleAppDll = LocateSampleAppDll();
+string sampleAppDll = LocateDll("SampleApp");
 
 try
 {
-    if (longPoll)
+    if (proxyMode)
+    {
+        await RunProxySweepAsync();
+    }
+    else if (longPoll)
     {
         await RunLongPollAsync();
     }
@@ -256,6 +272,112 @@ async Task RunRegimesAsync()
     // E[k/(k+2)] for k ~ Binomial(2, p). In the idle regime p gains ~wait/period of
     // lingering receive per cycle.
     static double ShareWhenOpenFractionIs(double p) => (2 * p * (1 - p)) / 3 + (p * p) / 2;
+}
+
+// The Istio model: pods are completely vanilla consumers (in-app gate disabled), and the
+// PWM shaping happens in the SqsProxy sitting between them and the queue. Each pool hits
+// its own proxy listener port — standing in for per-workload sidecar config — and the
+// proxy watches the same weights file the pods would have. Same weight sweep as the
+// default demo, so the results are directly comparable.
+async Task RunProxySweepAsync()
+{
+    var phaseDuration = TimeSpan.FromSeconds(quick ? 15 : 30);
+    (double Weight, double Target)[] phases = [(CanaryWeight, 0.20), (1.0, 0.50), (0.0, 0.00)];
+    const int PrimaryPort = 4610;
+    const int CanaryPort = 4611;
+
+    WriteWeights(phases[0].Weight);
+
+    // Start the proxy.
+    var proxyPsi = new ProcessStartInfo("dotnet", $"exec \"{LocateDll("SqsProxy")}\"")
+    {
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+    };
+    proxyPsi.Environment["UPSTREAM"] = flociUrl;
+    proxyPsi.Environment["PRIMARY_PORT"] = PrimaryPort.ToString(CultureInfo.InvariantCulture);
+    proxyPsi.Environment["CANARY_PORT"] = CanaryPort.ToString(CultureInfo.InvariantCulture);
+    proxyPsi.Environment["WEIGHTS_FILE"] = weightsFile;
+    proxyPsi.Environment["PWM_PERIOD_SECONDS"] = "10";
+
+    using var proxy = Process.Start(proxyPsi) ?? throw new InvalidOperationException("Failed to start SqsProxy.");
+    proxy.ErrorDataReceived += (_, e) =>
+    {
+        if (!string.IsNullOrWhiteSpace(e.Data))
+        {
+            Console.Error.WriteLine($"  [proxy] {e.Data}");
+        }
+    };
+    proxy.BeginErrorReadLine();
+    proxy.BeginOutputReadLine();
+
+    var pods = new List<PodProcess>();
+    try
+    {
+        using var health = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+        await WaitUntilAsync(
+            async () =>
+            {
+                try
+                {
+                    using var response = await health.GetAsync($"http://127.0.0.1:{PrimaryPort}/healthz");
+                    return response.IsSuccessStatusCode;
+                }
+                catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+                {
+                    return false;
+                }
+            },
+            TimeSpan.FromSeconds(15),
+            "SqsProxy did not become healthy");
+        Console.WriteLine($"  proxy up: primary → :{PrimaryPort}, canary → :{CanaryPort}, upstream {flociUrl}");
+
+        // Vanilla pods: no in-app throttle, each pool pointed at its proxy listener.
+        foreach (var (name, pool) in new[] { ("primary-1", "primary"), ("primary-2", "primary"), ("canary-1", "canary"), ("canary-2", "canary") })
+        {
+            var env = PodEnv(pwmPeriodSeconds: 10, receiveWaitSeconds: 1, handlerWorkMs: 5);
+            env["GATE_ENABLED"] = "false";
+            env["SQS_ENDPOINT"] = $"http://127.0.0.1:{(pool == "canary" ? CanaryPort : PrimaryPort)}";
+            pods.Add(PodProcess.Start(name, pool, sampleAppDll, env));
+        }
+
+        Console.WriteLine($"  started {pods.Count} vanilla pods, waiting for them to come up...");
+        await WaitUntilAsync(
+            () => Task.FromResult(pods.All(p => p.HasReported)),
+            TimeSpan.FromSeconds(90),
+            "pods did not start reporting");
+
+        foreach (var (weight, target) in phases)
+        {
+            WriteWeights(weight);
+            Console.WriteLine($"Canary weight → {weight:0.00} (signal read by the PROXY; steady load {SteadyMessagesPerSecond} msg/s for {phaseDuration.TotalSeconds:0}s)");
+
+            await Task.Delay(TimeSpan.FromSeconds(4));
+            var before = Snapshot(pods);
+            await PublishSteadyAsync(SteadyMessagesPerSecond, phaseDuration);
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            Report(pods, before, $"weight {weight:0.00}", target);
+            Console.WriteLine();
+        }
+
+        ReportLatency(pods);
+    }
+    finally
+    {
+        DisposePods(pods);
+        try
+        {
+            if (!proxy.HasExited)
+            {
+                proxy.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
 }
 
 // Validates that the gate throttle never strands messages: casualties (a message caught
@@ -573,16 +695,16 @@ static async Task WaitUntilAsync(Func<Task<bool>> condition, TimeSpan timeout, s
     throw new TimeoutException(timeoutMessage);
 }
 
-string LocateSampleAppDll()
+string LocateDll(string projectName)
 {
     // With the repo's UseArtifactsOutput layout, sibling project outputs live at
-    // artifacts/bin/<Project>/<configuration>/. Resolve SampleApp's relative to our own.
+    // artifacts/bin/<Project>/<configuration>/. Resolve them relative to our own.
     string baseDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
     string configuration = Path.GetFileName(baseDir);
-    string dll = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "SampleApp", configuration, "SampleApp.dll"));
+    string dll = Path.GetFullPath(Path.Combine(baseDir, "..", "..", projectName, configuration, $"{projectName}.dll"));
     if (!File.Exists(dll))
     {
-        throw new FileNotFoundException($"SampleApp.dll not found at {dll}; build the SampleApp project first.");
+        throw new FileNotFoundException($"{projectName}.dll not found at {dll}; build the {projectName} project first.");
     }
 
     return dll;

--- a/spikes/CanaryPolling/Demo/Program.cs
+++ b/spikes/CanaryPolling/Demo/Program.cs
@@ -40,9 +40,9 @@ bool quick = args.Contains("--quick");
 
 // --proxy: shape traffic in an SQS-aware proxy between the pods and the queue (the
 // Istio/Envoy model) instead of inside the pods — pods run as completely vanilla
-// consumers (GATE_ENABLED=false) pointed at a per-pool proxy listener. floci-only:
-// an explicit (non-transparent) proxy in front of real AWS would need to re-sign
-// requests, because SigV4 covers the Host header (see README).
+// consumers with zero canary configuration, pointed at a per-pool proxy listener.
+// floci-only: an explicit (non-transparent) proxy in front of real AWS would need to
+// re-sign requests, because SigV4 covers the Host header (see README).
 bool proxyMode = args.Contains("--proxy");
 if (proxyMode && useAws)
 {
@@ -274,11 +274,11 @@ async Task RunRegimesAsync()
     static double ShareWhenOpenFractionIs(double p) => (2 * p * (1 - p)) / 3 + (p * p) / 2;
 }
 
-// The Istio model: pods are completely vanilla consumers (in-app gate disabled), and the
-// PWM shaping happens in the SqsProxy sitting between them and the queue. Each pool hits
-// its own proxy listener port — standing in for per-workload sidecar config — and the
-// proxy watches the same weights file the pods would have. Same weight sweep as the
-// default demo, so the results are directly comparable.
+// The Istio model: pods are completely vanilla consumers — the in-app gate simply does
+// not exist for them (no weights file configured), and ALL the shaping happens in the
+// SqsProxy sitting between them and the queue. Each pool hits its own proxy listener
+// port — standing in for per-workload sidecar config — and only the proxy watches the
+// weights file. Same weight sweep as the default demo, so results are comparable.
 async Task RunProxySweepAsync()
 {
     var phaseDuration = TimeSpan.FromSeconds(quick ? 15 : 30);
@@ -333,16 +333,19 @@ async Task RunProxySweepAsync()
             "SqsProxy did not become healthy");
         Console.WriteLine($"  proxy up: primary → :{PrimaryPort}, canary → :{CanaryPort}, upstream {flociUrl}");
 
-        // Vanilla pods: no in-app throttle, each pool pointed at its proxy listener.
+        // Truly vanilla pods: no weights file, no PWM knobs — zero canary configuration.
+        // The only pool-specific setting is which endpoint they talk to, standing in for
+        // Istio's transparent per-workload interception.
         foreach (var (name, pool) in new[] { ("primary-1", "primary"), ("primary-2", "primary"), ("canary-1", "canary"), ("canary-2", "canary") })
         {
             var env = PodEnv(pwmPeriodSeconds: 10, receiveWaitSeconds: 1, handlerWorkMs: 5);
-            env["GATE_ENABLED"] = "false";
+            env.Remove("WEIGHTS_FILE");
+            env.Remove("PWM_PERIOD_SECONDS");
             env["SQS_ENDPOINT"] = $"http://127.0.0.1:{(pool == "canary" ? CanaryPort : PrimaryPort)}";
             pods.Add(PodProcess.Start(name, pool, sampleAppDll, env));
         }
 
-        Console.WriteLine($"  started {pods.Count} vanilla pods, waiting for them to come up...");
+        Console.WriteLine($"  started {pods.Count} vanilla pods (zero canary config), waiting for them to come up...");
         await WaitUntilAsync(
             () => Task.FromResult(pods.All(p => p.HasReported)),
             TimeSpan.FromSeconds(90),

--- a/spikes/CanaryPolling/Directory.Packages.props
+++ b/spikes/CanaryPolling/Directory.Packages.props
@@ -1,0 +1,9 @@
+<Project>
+  <!-- Extend the repo's central package versions with the released JustSaying
+       packages: the spike tests published bits, not the local source. -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)..'))" />
+  <ItemGroup>
+    <PackageVersion Include="JustSaying" Version="8.1.1" />
+    <PackageVersion Include="JustSaying.Extensions.DependencyInjection.Microsoft" Version="8.1.1" />
+  </ItemGroup>
+</Project>

--- a/spikes/CanaryPolling/README.md
+++ b/spikes/CanaryPolling/README.md
@@ -122,6 +122,12 @@ opens mid-park. Requests are never mutated and never cancelled, so the SigV4 sig
 and the zero-casualty property both survive. Sends, deletes and queue management pass
 straight through.
 
+"Vanilla" is literal: in proxy mode the pods receive **no canary configuration at all** —
+no weights file, no PWM knobs, no flags (the in-app gate only exists when a weights file
+is configured). The pod behaves exactly as any existing SQS consumer does today; an
+off-window poll just looks like an empty long poll, which is ordinary SQS behaviour, not
+something the application reacts to. The proxy owns the entire mechanism.
+
 Measured (`--proxy`, floci, same sweep as the in-app gate): **17–20% / 49–51% / 0.0%**
 against 20/50/0 targets, casualties 0, max end-to-end latency 0.1s — indistinguishable
 from the in-app gate, with zero application involvement.

--- a/spikes/CanaryPolling/README.md
+++ b/spikes/CanaryPolling/README.md
@@ -19,11 +19,15 @@ SampleApp/   the consumer "pod" — what a real service would ship
   PoolWeightWatcher.cs   the rollout signal: a watched weights file (ConfigMap-shaped)
   OrderHandler.cs        stand-in message processing + demo stats line
   BusRunnerService.cs    starts the bus
+SqsProxy/    the infra-level alternative (the Istio model): an SQS-aware proxy that
+             runs the same PWM gate between vanilla pods and the queue — the logic an
+             Envoy ext_proc/WASM filter would host (see the proxy section below)
 Demo/        demo/load orchestration only — nothing here is part of the mechanism
   Program.cs             starts floci or targets real AWS, spawns pods as separate OS
                          processes, writes the weights file, generates load, reports
   PodProcess.cs          process launch + stdout stats collection
-Shared/      message contract + floci-pointed AWS client factory
+Shared/      message contract, floci client factory, and the shared throttle
+             primitives (PwmGate clock + PoolWeightWatcher signal)
 ```
 
 Pods run as separate OS processes because that's the honest version of "pods cannot
@@ -104,6 +108,51 @@ holds even when every worker is sitting idle in an empty long poll.
    drains/evaluation windows cover ≥10 periods; 10s suits weights ≥ ~20%, stretch it as
    the weight shrinks so the on-window (`period × weight`) stays at a few seconds.
 
+## The proxy variant: shaping at the infrastructure layer (the Istio model)
+
+It's been suggested the same result could come from proxying the SQS API (e.g. Istio
+intercepting egress to SQS) and doing the "routing" there. That intuition holds, with
+one reframe: for a pull-based queue there's nothing to *route* — there's one queue and
+the pods come to it — but the proxy can run **exactly the same PWM gate** on the
+`ReceiveMessage` calls passing through it. `SqsProxy/` prototypes this: pods run as
+**completely vanilla consumers** (in-app gate off), each pool points at its own proxy
+listener, and the proxy parks off-window `ReceiveMessage` calls for up to their own
+`WaitTimeSeconds` before answering with an empty poll — forwarding them if the window
+opens mid-park. Requests are never mutated and never cancelled, so the SigV4 signature
+and the zero-casualty property both survive. Sends, deletes and queue management pass
+straight through.
+
+Measured (`--proxy`, floci, same sweep as the in-app gate): **17–20% / 49–51% / 0.0%**
+against 20/50/0 targets, casualties 0, max end-to-end latency 0.1s — indistinguishable
+from the in-app gate, with zero application involvement.
+
+Mapping the prototype onto a real Istio deployment:
+
+- **Interception**: a `ServiceEntry` for `sqs.<region>.amazonaws.com` brings SQS into
+  the mesh; sidecars capture the egress. Because SQS is HTTPS-only, the filter can only
+  see the API call if the app→sidecar leg is plaintext with **TLS origination** at the
+  sidecar/egress gateway (`DestinationRule`) — a real config decision, not a default.
+- **The filter**: parking a request needs async timers, which rules out Envoy's Lua
+  filter. The real options are an **ext_proc** gRPC processor or a **WASM plugin** — or
+  skip sidecar filters entirely and deploy this prototype as a small in-mesh egress
+  service, which is operationally the simplest and what the prototype literally is.
+- **Pool identity + weight**: per-`Deployment` filter config via `workloadSelector`
+  (the prototype's two listener ports stand in for this), with the weight pushed to the
+  filter/service by rollout tooling — the same single-writer signal as the weights file.
+- **SigV4 is the sharp edge**: the Host header is signed, so a *transparent* intercept
+  (Istio) preserves signatures against real AWS, but an *explicit* proxy (SDK
+  `ServiceURL` pointed at it, like this local prototype) would have to re-sign every
+  forwarded request. That's why `--proxy` is floci-only locally; in-cluster Istio
+  doesn't have this problem.
+
+Trade-offs vs the in-app gate: the proxy needs **no app or library changes at all** and
+shapes *every* SQS consumer stack (raw SDK, AWS.Messaging, Brighter — not just
+JustSaying), with one central knob. In exchange you put a new component on the critical
+consumption path (proxy outage = consumption outage), it must understand both SQS wire
+protocols (JSON and Query), and the TLS/identity plumbing above is real work. The
+in-app gate is ~60 lines in services you already own; the proxy is the better shape if
+canarying needs to cover consumers you *don't* own.
+
 ## How we got here (variants tried and rejected)
 
 - **Proportional poll pacing** (same middleware seam, delay each poll by
@@ -148,6 +197,8 @@ dotnet run -- --regimes --aws     # the real thing: AWS SQS via your CLI credent
                                   #   queues are created with a unique name and deleted after)
 dotnet run -- --longpoll --aws    # steady/idle at the recommended config + 1s-period churn,
                                   #   with end-to-end latency + casualty accounting
+dotnet run -- --proxy             # the Istio model: vanilla pods, PWM in the SqsProxy
+                                  #   (floci-only — see the proxy section on SigV4)
 dotnet run -- --quick             # shorter phases, noisier numbers (combines with the above)
 FLOCI_URL=http://... dotnet run   # use an existing floci/SQS-compatible endpoint
 ```

--- a/spikes/CanaryPolling/README.md
+++ b/spikes/CanaryPolling/README.md
@@ -1,0 +1,193 @@
+# Canary polling demo
+
+**Question:** can two pools of JustSaying pods consuming the *same* SQS queue split traffic
+roughly N/100−N purely by adjusting their own polling, given only a broadcast signal
+(no pod-to-pod communication, no infrastructure routing, no pod scaling)?
+
+**Answer: yes — validated against real AWS SQS across all three traffic regimes.** The
+mechanism is pulse-width modulation (PWM) of JustSaying's built-in
+`IMessageReceivePauseSignal`, using public API only — no changes to JustSaying itself.
+
+## Layout
+
+```
+SampleApp/   the consumer "pod" — what a real service would ship
+  Program.cs             plain JustSaying subscriber wired up with the pieces below
+  GatedReceiveMiddleware.cs ← the mechanism: a PWM gate in the receive middleware —
+                         cooperative, never cancels a poll (PwmGate is the clock)
+  PoolWeightWatcher.cs   the rollout signal: a watched weights file (ConfigMap-shaped)
+  OrderHandler.cs        stand-in message processing + demo stats line
+  BusRunnerService.cs    starts the bus
+Demo/        demo/load orchestration only — nothing here is part of the mechanism
+  Program.cs             starts floci or targets real AWS, spawns pods as separate OS
+                         processes, writes the weights file, generates load, reports
+  PodProcess.cs          process launch + stdout stats collection
+Shared/      message contract + floci-pointed AWS client factory
+```
+
+Pods run as separate OS processes because that's the honest version of "pods cannot
+communicate": the only things they share are the queue and the signal file.
+
+## The mechanism
+
+`GatedReceiveMiddleware` sits in JustSaying's receive pipeline
+(`Subscriptions.WithDefaults(d => d.WithCustomMiddleware(...))`) and enforces a PWM
+clock: for `weight × period` of each cycle polls pass through untouched — the pod
+competes for messages *exactly like an unthrottled pod* — and for the rest of the cycle
+the next poll simply isn't started, at a random phase per pod. Because an on-window pod
+is indistinguishable from an unthrottled one, the achieved share depends only on the
+duty cycle — not on how the broker arbitrates between concurrent long-pollers. And
+because a poll, once issued, always completes naturally, no message is ever stranded
+mid-delivery: the casualty rate is zero by construction.
+
+The one coupling this keeps: the last poll of a window lingers up to the receive wait
+into the off-window, so the wait must stay well under the period (1s wait / 10s period
+validated; under flowing traffic polls return in milliseconds, so the linger only exists
+on an idle queue). An earlier iteration instead pulsed `IMessageReceivePauseSignal`,
+which JustSaying 8.1.1 honours by *cancelling* the in-flight poll — prompt, and the
+right behaviour for operational "stop consuming now", but the cancellations strand a
+small percentage of messages until the visibility timeout (see the casualties section);
+that variant lost the A/B and its code was removed.
+
+Weight semantics: `1.0` = normal pod, `0.0` = fully parked (a clean "drain this pool"
+switch), in between = duty cycle. The percentage → weight mapping belongs to rollout
+tooling, which knows the replica counts (the demo uses weight 0.327 to target 20% with
+2v2 pods; the modeled share differs a little per regime and is printed per scenario).
+
+The signal is a JSON file mapping pool → weight, re-read on timestamp change:
+`{"primary": 1.0, "canary": 0.33}`. A ConfigMap-mounted file (updated in place by
+Kubernetes, no restarts) fits this exactly; an env-refreshed flag service works the same.
+
+## Results on real AWS SQS (`--regimes --aws`, 20% canary target, 2v2 pods)
+
+| Regime | What it exercises | Observed | Modeled |
+|---|---|---|---|
+| Backlog (12k pre-loaded, pods flat out) | backpressure / poll-rate share | **27.5%** | 24.6% |
+| Steady (30 msg/s, queue near-empty) | continuous arrival-limited flow | **23.1%** | 20.0% |
+| Idle (1 msg / 2s, all pods parked) | SQS fairness among parked long-polls | **20.0%** | ~25% |
+
+The idle result is the important one: **real SQS distributes sparse messages roughly
+uniformly among parked long-pollers**, so the split holds even when every worker is
+sitting idle in an empty long poll. The weight-sweep demo (canary 0.33 → 1.0 → 0.0 under
+steady load) tracks 20% → 50% → 0% within a couple of points, with changes applying in
+seconds, in-place.
+
+## Hard-won tuning rules (violate these and the split degrades badly)
+
+1. **Keep the in-process pipeline shallow.** Pausing only stops *fetching* — anything
+   already prefetched/buffered still gets processed during the off-window. With
+   JustSaying's defaults (prefetch 10, multiplexer capacity 100) a canary pod hoarded
+   100+ messages per on-window under backlog and the observed share was 42.5% instead of
+   ~25%. With prefetch 5 / multiplexer 10 it landed at 27.5%. Bound the buffered work to
+   well under one PWM off-window of processing.
+2. **(Pre-8.1.1 only) Keep the receive wait well under the PWM period.** Before
+   JustSaying 8.1.1, a pause didn't cancel an already-parked long poll, which lingered up
+   to the wait time into the off-window — with a production-default 20s wait and a short
+   period the canary never stopped listening and the split collapsed toward 50/50.
+   **JustSaying 8.1.1 / 7.4.1 fix this** ([#2287](https://github.com/justeattakeaway/JustSaying/issues/2287)):
+   `Pause()` now cancels the in-flight receive, and the 20s-wait + 10s-period combination
+   measured 23.5% steady / ~11-29% idle (small samples) on real SQS. See the casualties
+   section below for the cost.
+3. **The averaging window must span many PWM periods.** A backlog that drains in 1–2
+   periods gets a lumpy split (whichever pods happened to be on). Size the period so
+   drains/evaluation windows cover ≥10 periods.
+
+## Casualties under pause-cancellation (the removed variant, measured on real AWS)
+
+Cancelling a receive that SQS is mid-way through serving leaves those messages invisible
+until the visibility timeout (30s), when they are redelivered — "casualties": received but
+not processed until ~30s later. Measured on real SQS with 20s waits (casualty = handled
+with >15s end-to-end latency; normal latency is well under 1s):
+
+| Config | Cancellations | Casualty rate | Notes |
+|---|---|---|---|
+| Period 10s (sane) | ~6/min per canary pod | **1.3–1.8%** | max latency 60–120s, nothing dead-lettered |
+| Period 1s (extreme churn) | ~1/s per canary pod | **2.8–4.4%** | ~0.4% still bouncing after 2 min; **2 of 1,785 messages dead-lettered in one run (~0.1%)** |
+
+Details worth knowing:
+
+- Casualties bounce in ~30s steps and can bounce repeatedly (max observed 120s = 4
+  bounces). With a 1s period the 30s visibility timeout is an exact multiple of the PWM
+  period, so a redelivery lands at the *same phase* and can be cancelled again —
+  **jitter the period** (e.g. 9–11s randomised per cycle) to break the resonance.
+- Each bounce increments `ApproximateReceiveCount`, so enough bounces exhaust the error
+  queue redrive and the message is **dead-lettered without ever failing in a handler**.
+  Only observed in the extreme 1s-period config. Mitigations: longer/jittered period,
+  and/or raise the retry count on queues subject to canary throttling.
+- Messages are never lost — delayed or dead-lettered only.
+- One full-length run showed a steady-phase anomaly (47% share, one canary apparently
+  unthrottled for a minute) that did not reproduce across two further runs; the weight
+  watcher now logs read failures so a stuck weight would be visible.
+
+The spike now consumes the released `JustSaying` 8.1.1 packages from NuGet (see
+`Directory.Packages.props`), so these numbers reflect what ships.
+
+## The A/B that decided it (gate vs pause-signal variant)
+
+Same PWM clock, different enforcement point: instead of pulsing the pause signal (which
+cancels the in-flight poll), `GatedReceiveMiddleware` sits in the receive pipeline
+(`WithCustomMiddleware`) and simply doesn't *start* the next poll until the on-window
+opens. A poll, once issued, always completes naturally — so casualties are impossible by
+construction. The trade: the last poll of a window lingers up to the receive wait into
+the off-window, so the wait must stay well under the period (1s wait / 10s period; under
+flowing traffic polls return in milliseconds anyway, so the linger only exists on an
+idle queue). Works on any JustSaying version — no 8.1.1 dependency.
+
+A/B on real AWS SQS, identical scenarios (20% target):
+
+| | Pause signal + 8.1.1 cancellation (20s wait) | Middleware gate (1s wait) |
+|---|---|---|
+| Steady split | 23.5% | **19.1%** |
+| Idle split | ~11–29% (small n) | **20.0%** |
+| Churn split (1s period) | 16.9% | **21.4%** |
+| Casualties (churn) | 2.8–4.4%, max 120s, ~0.1% DLQ'd | **0, max latency 0.2s, 0 DLQ'd** |
+| Messages accounted | ~99.6% within 2 min | **100%** |
+
+Verdict: use the gate for the always-on traffic-shaping loop; keep the pause signal
+(with its 8.1.1 prompt-cancel behaviour) for what it's really for — operational "stop
+consuming now". The 1s receive wait costs ~3¢/pod/day in empty requests and does not
+affect delivery latency.
+
+## Emulator caveat
+
+Both LocalSqsSnsMessaging in-memory and floci showed **deterministic, unfair arbitration
+among parked long-pollers when the queue is idle** (in the sparse test on floci, one
+primary pod received *every* message; the canary got zero). All waiters park on one
+`Channel<Message>` and the wake race systematically favours particular pollers. Fine for
+functional tests, misleading for fairness experiments — validate distribution behaviour
+on real SQS. (Possibly worth randomizing in LocalSqsSnsMessaging to better model SQS.)
+
+## Running it
+
+```
+cd spikes/CanaryPolling/Demo
+dotnet run                        # weight sweep on floci (starts a container on :4599 if needed)
+dotnet run -- --regimes           # backlog/steady/idle validation on floci
+dotnet run -- --regimes --aws     # the real thing: AWS SQS via your CLI credentials (~10 min;
+                                  #   queues are created with a unique name and deleted after)
+dotnet run -- --longpoll --aws    # steady/idle at the recommended config + 1s-period churn,
+                                  #   with end-to-end latency + casualty accounting
+dotnet run -- --quick             # shorter phases, noisier numbers (combines with the above)
+FLOCI_URL=http://... dotnet run   # use an existing floci/SQS-compatible endpoint
+```
+
+AWS mode resolves the region from the CLI and borrows credentials via
+`aws configure export-credentials`, so `aws login` / SSO sessions work.
+
+## Notes for a real rollout
+
+- Canary traffic arrives in bursts of `period × weight` — fine for "N% of volume over an
+  evaluation window", not per-second smoothness.
+- Message latency is unaffected while the primary pool runs unthrottled (it always has
+  pollers live); don't invert that (primary 0, canary <1) without thinking about latency.
+- The gate only defers polls; in-flight messages complete normally. No interaction with
+  visibility timeouts, error queues, or redrive. (A reject/re-release scheme via
+  `ChangeMessageVisibility(0)` was considered and dropped: it inflates
+  `ApproximateReceiveCount` and DLQs a slice of traffic under redrive policies.)
+- An earlier iteration tried pacing individual `ReceiveMessage` calls proportionally in
+  the same middleware seam: exact under backlog but broker-arbitration-dependent when the
+  queue is near-empty (starved to ~7% on the emulators). PWM won on robustness; the gate
+  keeps PWM but enforces it at that seam.
+- Productizing inside JustSaying would be a small opt-in helper wiring a weight source to
+  the gate middleware (`AddCanaryPolling(...)`); everything here works today from app
+  code, on any JustSaying version.

--- a/spikes/CanaryPolling/README.md
+++ b/spikes/CanaryPolling/README.md
@@ -4,9 +4,10 @@
 roughly N/100−N purely by adjusting their own polling, given only a broadcast signal
 (no pod-to-pod communication, no infrastructure routing, no pod scaling)?
 
-**Answer: yes — validated against real AWS SQS across all three traffic regimes.** The
-mechanism is pulse-width modulation (PWM) of JustSaying's built-in
-`IMessageReceivePauseSignal`, using public API only — no changes to JustSaying itself.
+**Answer: yes — validated against real AWS SQS across backlog, steady and idle traffic,
+with zero stranded messages.** The mechanism is a pulse-width-modulation (PWM) gate in
+JustSaying's receive middleware — public API only, no changes to JustSaying itself, and
+no dependency on any particular JustSaying version.
 
 ## Layout
 
@@ -34,20 +35,17 @@ communicate": the only things they share are the queue and the signal file.
 (`Subscriptions.WithDefaults(d => d.WithCustomMiddleware(...))`) and enforces a PWM
 clock: for `weight × period` of each cycle polls pass through untouched — the pod
 competes for messages *exactly like an unthrottled pod* — and for the rest of the cycle
-the next poll simply isn't started, at a random phase per pod. Because an on-window pod
-is indistinguishable from an unthrottled one, the achieved share depends only on the
-duty cycle — not on how the broker arbitrates between concurrent long-pollers. And
-because a poll, once issued, always completes naturally, no message is ever stranded
-mid-delivery: the casualty rate is zero by construction.
+the next poll simply isn't started, at a random phase per pod.
 
-The one coupling this keeps: the last poll of a window lingers up to the receive wait
-into the off-window, so the wait must stay well under the period (1s wait / 10s period
-validated; under flowing traffic polls return in milliseconds, so the linger only exists
-on an idle queue). An earlier iteration instead pulsed `IMessageReceivePauseSignal`,
-which JustSaying 8.1.1 honours by *cancelling* the in-flight poll — prompt, and the
-right behaviour for operational "stop consuming now", but the cancellations strand a
-small percentage of messages until the visibility timeout (see the casualties section);
-that variant lost the A/B and its code was removed.
+Two properties fall out of that:
+
+- **The split doesn't depend on broker arbitration.** An on-window pod is
+  indistinguishable from an unthrottled one, so the achieved share depends only on the
+  duty cycle — not on how SQS picks between concurrent long-pollers.
+- **No message is ever stranded.** A poll, once issued, always completes naturally and
+  its messages are processed. There is nothing to cancel, so there's no way to leave a
+  message invisible mid-delivery. Measured casualty rate is zero, even when pulsing at a
+  1s period (see the history section for the variant where this wasn't true).
 
 Weight semantics: `1.0` = normal pod, `0.0` = fully parked (a clean "drain this pool"
 switch), in between = duty cycle. The percentage → weight mapping belongs to rollout
@@ -57,105 +55,88 @@ tooling, which knows the replica counts (the demo uses weight 0.327 to target 20
 The signal is a JSON file mapping pool → weight, re-read on timestamp change:
 `{"primary": 1.0, "canary": 0.33}`. A ConfigMap-mounted file (updated in place by
 Kubernetes, no restarts) fits this exactly; an env-refreshed flag service works the same.
+Weight changes apply within a PWM cycle, in-place.
 
-## Results on real AWS SQS (`--regimes --aws`, 20% canary target, 2v2 pods)
+## Results on real AWS SQS (gate mechanism, 20% canary target, 2v2 pods)
+
+Traffic regimes (`--regimes --aws`; 1s receive wait, 10s period — 2s for the backlog):
 
 | Regime | What it exercises | Observed | Modeled |
 |---|---|---|---|
-| Backlog (12k pre-loaded, pods flat out) | backpressure / poll-rate share | **27.5%** | 24.6% |
-| Steady (30 msg/s, queue near-empty) | continuous arrival-limited flow | **23.1%** | 20.0% |
-| Idle (1 msg / 2s, all pods parked) | SQS fairness among parked long-polls | **20.0%** | ~25% |
+| Backlog (12k pre-loaded, pods flat out) | backpressure / poll-rate share | **28.7%** | 24.6% |
+| Steady (30 msg/s, queue near-empty) | continuous arrival-limited flow | **22.8%** | 20.0% |
+| Idle (1 msg / 2s, all pods parked) | SQS fairness among parked long-polls | **28.3%** (n=120) | 25.4% |
 
-The idle result is the important one: **real SQS distributes sparse messages roughly
-uniformly among parked long-pollers**, so the split holds even when every worker is
-sitting idle in an empty long poll. The weight-sweep demo (canary 0.33 → 1.0 → 0.0 under
-steady load) tracks 20% → 50% → 0% within a couple of points, with changes applying in
-seconds, in-place.
+Latency/casualty validation (`--longpoll --aws`), including a deliberately brutal churn
+scenario — a **1-second** PWM period, i.e. the canaries stop and start roughly every
+660ms under 30 msg/s of load:
 
-## Hard-won tuning rules (violate these and the split degrades badly)
+| Scenario | Split | Casualties (≥15s latency) | Max latency | Accounted for |
+|---|---|---|---|---|
+| Steady | 19.1% | 0 | 0.2s | 100% |
+| Idle | 20.0% | 0 | 0.2s | 100% |
+| Churn, 1s period | 21.4% | **0** | **0.2s** | **3,486 / 3,486** |
 
-1. **Keep the in-process pipeline shallow.** Pausing only stops *fetching* — anything
+Nothing was dead-lettered in any run. The weight-sweep demo (canary 0.33 → 1.0 → 0.0
+under steady load) tracks 20% → 50% → 0% within a couple of points, with changes
+applying in seconds.
+
+The idle result answers the question this whole approach hinges on: **real SQS
+distributes sparse messages roughly uniformly among parked long-pollers**, so the split
+holds even when every worker is sitting idle in an empty long poll.
+
+## Tuning rules (violate these and the split degrades)
+
+1. **Keep the receive wait well under the PWM period.** The gate never interrupts a
+   poll, so the last poll of each on-window lingers up to the wait time into the
+   off-window. 1s wait with a 10s period is the validated combination; the linger only
+   exists at all on an idle queue (under flowing traffic polls return in milliseconds).
+   A 1s long-poll wait costs ~3¢/pod/day in empty requests and doesn't affect delivery
+   latency.
+2. **Keep the in-process pipeline shallow.** Gating only defers *fetching* — anything
    already prefetched/buffered still gets processed during the off-window. With
-   JustSaying's defaults (prefetch 10, multiplexer capacity 100) a canary pod hoarded
-   100+ messages per on-window under backlog and the observed share was 42.5% instead of
-   ~25%. With prefetch 5 / multiplexer 10 it landed at 27.5%. Bound the buffered work to
-   well under one PWM off-window of processing.
-2. **(Pre-8.1.1 only) Keep the receive wait well under the PWM period.** Before
-   JustSaying 8.1.1, a pause didn't cancel an already-parked long poll, which lingered up
-   to the wait time into the off-window — with a production-default 20s wait and a short
-   period the canary never stopped listening and the split collapsed toward 50/50.
-   **JustSaying 8.1.1 / 7.4.1 fix this** ([#2287](https://github.com/justeattakeaway/JustSaying/issues/2287)):
-   `Pause()` now cancels the in-flight receive, and the 20s-wait + 10s-period combination
-   measured 23.5% steady / ~11-29% idle (small samples) on real SQS. See the casualties
-   section below for the cost.
+   JustSaying's defaults (prefetch 10, multiplexer capacity 100) a throttled pod hoarded
+   100+ messages per on-window under backlog and its share inflated from ~25% to 42.5%.
+   With prefetch 5 / multiplexer 10 it landed at 28.7%. Bound the buffered work to well
+   under one off-window of processing.
 3. **The averaging window must span many PWM periods.** A backlog that drains in 1–2
    periods gets a lumpy split (whichever pods happened to be on). Size the period so
-   drains/evaluation windows cover ≥10 periods.
+   drains/evaluation windows cover ≥10 periods; 10s suits weights ≥ ~20%, stretch it as
+   the weight shrinks so the on-window (`period × weight`) stays at a few seconds.
 
-## Casualties under pause-cancellation (the removed variant, measured on real AWS)
+## How we got here (variants tried and rejected)
 
-Cancelling a receive that SQS is mid-way through serving leaves those messages invisible
-until the visibility timeout (30s), when they are redelivered — "casualties": received but
-not processed until ~30s later. Measured on real SQS with 20s waits (casualty = handled
-with >15s end-to-end latency; normal latency is well under 1s):
-
-| Config | Cancellations | Casualty rate | Notes |
-|---|---|---|---|
-| Period 10s (sane) | ~6/min per canary pod | **1.3–1.8%** | max latency 60–120s, nothing dead-lettered |
-| Period 1s (extreme churn) | ~1/s per canary pod | **2.8–4.4%** | ~0.4% still bouncing after 2 min; **2 of 1,785 messages dead-lettered in one run (~0.1%)** |
-
-Details worth knowing:
-
-- Casualties bounce in ~30s steps and can bounce repeatedly (max observed 120s = 4
-  bounces). With a 1s period the 30s visibility timeout is an exact multiple of the PWM
-  period, so a redelivery lands at the *same phase* and can be cancelled again —
-  **jitter the period** (e.g. 9–11s randomised per cycle) to break the resonance.
-- Each bounce increments `ApproximateReceiveCount`, so enough bounces exhaust the error
-  queue redrive and the message is **dead-lettered without ever failing in a handler**.
-  Only observed in the extreme 1s-period config. Mitigations: longer/jittered period,
-  and/or raise the retry count on queues subject to canary throttling.
-- Messages are never lost — delayed or dead-lettered only.
-- One full-length run showed a steady-phase anomaly (47% share, one canary apparently
-  unthrottled for a minute) that did not reproduce across two further runs; the weight
-  watcher now logs read failures so a stuck weight would be visible.
-
-The spike now consumes the released `JustSaying` 8.1.1 packages from NuGet (see
-`Directory.Packages.props`), so these numbers reflect what ships.
-
-## The A/B that decided it (gate vs pause-signal variant)
-
-Same PWM clock, different enforcement point: instead of pulsing the pause signal (which
-cancels the in-flight poll), `GatedReceiveMiddleware` sits in the receive pipeline
-(`WithCustomMiddleware`) and simply doesn't *start* the next poll until the on-window
-opens. A poll, once issued, always completes naturally — so casualties are impossible by
-construction. The trade: the last poll of a window lingers up to the receive wait into
-the off-window, so the wait must stay well under the period (1s wait / 10s period; under
-flowing traffic polls return in milliseconds anyway, so the linger only exists on an
-idle queue). Works on any JustSaying version — no 8.1.1 dependency.
-
-A/B on real AWS SQS, identical scenarios (20% target):
-
-| | Pause signal + 8.1.1 cancellation (20s wait) | Middleware gate (1s wait) |
-|---|---|---|
-| Steady split | 23.5% | **19.1%** |
-| Idle split | ~11–29% (small n) | **20.0%** |
-| Churn split (1s period) | 16.9% | **21.4%** |
-| Casualties (churn) | 2.8–4.4%, max 120s, ~0.1% DLQ'd | **0, max latency 0.2s, 0 DLQ'd** |
-| Messages accounted | ~99.6% within 2 min | **100%** |
-
-Verdict: use the gate for the always-on traffic-shaping loop; keep the pause signal
-(with its 8.1.1 prompt-cancel behaviour) for what it's really for — operational "stop
-consuming now". The 1s receive wait costs ~3¢/pod/day in empty requests and does not
-affect delivery latency.
+- **Proportional poll pacing** (same middleware seam, delay each poll by
+  `duration / weight`): exact under backlog, but on a near-empty queue the share is
+  decided by how the broker arbitrates between parked long-pollers — it starved to ~7%
+  on the emulators. PWM replaced it because an on-window pod needs no arbitration
+  fairness at all.
+- **PWM by pulsing `IMessageReceivePauseSignal`**: worked, and drove a real JustSaying
+  fix — before 8.1.1/7.4.1 a pause didn't affect the in-flight long poll, so
+  production-default 20s waits swamped the off-windows
+  ([#2287](https://github.com/justeattakeaway/JustSaying/issues/2287)). 8.1.1 made
+  `Pause()` cancel the in-flight receive, which fixed the split (23.5% steady on a 20%
+  target with stock 20s waits) but at a price: a cancelled receive can strand messages
+  SQS was mid-way through serving, invisible until the 30s visibility timeout. Measured:
+  1.3–1.8% of messages delayed ≥30s at a 10s period, 2.8–4.4% at a 1s period with
+  multi-bounces to 120s (30s visibility being an exact multiple of the period means a
+  redelivery lands at the same PWM phase and gets re-cancelled), and ~0.1% dead-lettered
+  without ever failing in a handler. An A/B against the gate on identical scenarios
+  (gate: better split, zero casualties, 100% accounted) settled it, and the pause-signal
+  variant's code was removed from this spike. Pause + prompt cancellation remains the
+  right tool for its actual job — operational "stop consuming now" — just not for an
+  always-on shaping loop pulsing it six times a minute.
 
 ## Emulator caveat
 
 Both LocalSqsSnsMessaging in-memory and floci showed **deterministic, unfair arbitration
-among parked long-pollers when the queue is idle** (in the sparse test on floci, one
-primary pod received *every* message; the canary got zero). All waiters park on one
-`Channel<Message>` and the wake race systematically favours particular pollers. Fine for
-functional tests, misleading for fairness experiments — validate distribution behaviour
-on real SQS. (Possibly worth randomizing in LocalSqsSnsMessaging to better model SQS.)
+among parked long-pollers when the queue is idle** (in one sparse test on floci, a single
+pod received *every* message). All waiters park on one `Channel<Message>` and the wake
+race systematically favours particular pollers. Fine for functional tests, misleading for
+fairness experiments — validate distribution behaviour on real SQS. (The gate is largely
+immune — that's rather the point — but the *measurements* of fairness-sensitive variants
+were only trustworthy on real SQS. Write-up for the LocalSqsSnsMessaging project in
+`localsqssnsmessaging-longpoll-fairness.md`.)
 
 ## Running it
 
@@ -171,8 +152,11 @@ dotnet run -- --quick             # shorter phases, noisier numbers (combines wi
 FLOCI_URL=http://... dotnet run   # use an existing floci/SQS-compatible endpoint
 ```
 
-AWS mode resolves the region from the CLI and borrows credentials via
-`aws configure export-credentials`, so `aws login` / SSO sessions work.
+The spike consumes the released `JustSaying` 8.1.1 packages from NuGet (see
+`Directory.Packages.props`), so results reflect what ships. AWS mode resolves the region
+from the CLI and borrows credentials via `aws configure export-credentials`, so
+`aws login` / SSO sessions work (note the exported token can expire during long runs; if
+queue cleanup fails, delete queues prefixed `canary-orders-` manually).
 
 ## Notes for a real rollout
 
@@ -184,10 +168,6 @@ AWS mode resolves the region from the CLI and borrows credentials via
   visibility timeouts, error queues, or redrive. (A reject/re-release scheme via
   `ChangeMessageVisibility(0)` was considered and dropped: it inflates
   `ApproximateReceiveCount` and DLQs a slice of traffic under redrive policies.)
-- An earlier iteration tried pacing individual `ReceiveMessage` calls proportionally in
-  the same middleware seam: exact under backlog but broker-arbitration-dependent when the
-  queue is near-empty (starved to ~7% on the emulators). PWM won on robustness; the gate
-  keeps PWM but enforces it at that seam.
 - Productizing inside JustSaying would be a small opt-in helper wiring a weight source to
   the gate middleware (`AddCanaryPolling(...)`); everything here works today from app
   code, on any JustSaying version.

--- a/spikes/CanaryPolling/SampleApp/BusRunnerService.cs
+++ b/spikes/CanaryPolling/SampleApp/BusRunnerService.cs
@@ -1,0 +1,10 @@
+using JustSaying;
+using Microsoft.Extensions.Hosting;
+
+namespace SampleApp;
+
+/// <summary>Starts the JustSaying bus and keeps it listening until shutdown.</summary>
+public sealed class BusRunnerService(IMessagingBus bus) : BackgroundService
+{
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) => bus.StartAsync(stoppingToken);
+}

--- a/spikes/CanaryPolling/SampleApp/GatedReceiveMiddleware.cs
+++ b/spikes/CanaryPolling/SampleApp/GatedReceiveMiddleware.cs
@@ -1,0 +1,86 @@
+using System.Diagnostics;
+using Amazon.SQS.Model;
+using JustSaying.Messaging.Middleware.Receive;
+using Microsoft.Extensions.Logging;
+
+namespace SampleApp;
+
+/// <summary>
+/// The cooperative alternative to pulsing the pause signal: the same PWM clock, but
+/// enforced in the receive middleware, which sits in front of every ReceiveMessage call.
+/// During the on-window polls pass through untouched (the pod is indistinguishable from
+/// an unthrottled one); at the off-window boundary the *next* poll is simply not started
+/// until the window reopens. A poll, once issued, always completes naturally — nothing is
+/// ever cancelled, so no message is stranded invisible mid-delivery ("casualties").
+/// The cost: the final poll of a window lingers up to the receive wait time into the
+/// off-window, so the receive wait must be well under the PWM period (1s wait / 10s
+/// period validated). Works on any JustSaying version — no dependency on the 8.1.1
+/// pause-cancellation behaviour.
+/// </summary>
+public sealed class GatedReceiveMiddleware(PwmGate gate, ILogger<DefaultReceiveMessagesMiddleware> logger)
+    : DefaultReceiveMessagesMiddleware(logger)
+{
+    protected override async Task<IList<Message>> RunInnerAsync(
+        ReceiveMessagesContext context,
+        Func<CancellationToken, Task<IList<Message>>> func,
+        CancellationToken stoppingToken)
+    {
+        try
+        {
+            await gate.WaitForOnWindowAsync(stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown, or the receive-buffer read timeout (5 min default) elapsed while
+            // parked at weight 0. Return empty like the base middleware does on
+            // cancellation; the receive loop just tries again.
+            return [];
+        }
+
+        return await base.RunInnerAsync(context, func, stoppingToken).ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// The PWM clock: on for <c>weight × period</c>, off for the rest, random phase per pod.
+/// Weight comes from the watched rollout signal on every check, so changes apply within
+/// 250ms; weight 1 never gates, weight 0 parks the pod (checked every 250ms).
+/// </summary>
+public sealed class PwmGate(PoolWeightWatcher weights, TimeSpan period)
+{
+    private static readonly TimeSpan RecheckDelay = TimeSpan.FromMilliseconds(250);
+
+    private readonly long _startTimestamp = Stopwatch.GetTimestamp();
+    private readonly double _phaseOffsetMs = Random.Shared.NextDouble() * period.TotalMilliseconds;
+
+    public async Task WaitForOnWindowAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            double weight = weights.CurrentWeight;
+
+            if (weight >= 1d)
+            {
+                return;
+            }
+
+            if (weight > 0d)
+            {
+                double positionMs = (Stopwatch.GetElapsedTime(_startTimestamp).TotalMilliseconds + _phaseOffsetMs)
+                    % period.TotalMilliseconds;
+                if (positionMs < period.TotalMilliseconds * weight)
+                {
+                    return;
+                }
+
+                double untilWindowOpensMs = period.TotalMilliseconds - positionMs;
+                await Task.Delay(TimeSpan.FromMilliseconds(Math.Min(untilWindowOpensMs, RecheckDelay.TotalMilliseconds)), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await Task.Delay(RecheckDelay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/spikes/CanaryPolling/SampleApp/GatedReceiveMiddleware.cs
+++ b/spikes/CanaryPolling/SampleApp/GatedReceiveMiddleware.cs
@@ -1,5 +1,5 @@
-using System.Diagnostics;
 using Amazon.SQS.Model;
+using CanaryDemo.Shared;
 using JustSaying.Messaging.Middleware.Receive;
 using Microsoft.Extensions.Logging;
 
@@ -38,49 +38,5 @@ public sealed class GatedReceiveMiddleware(PwmGate gate, ILogger<DefaultReceiveM
         }
 
         return await base.RunInnerAsync(context, func, stoppingToken).ConfigureAwait(false);
-    }
-}
-
-/// <summary>
-/// The PWM clock: on for <c>weight × period</c>, off for the rest, random phase per pod.
-/// Weight comes from the watched rollout signal on every check, so changes apply within
-/// 250ms; weight 1 never gates, weight 0 parks the pod (checked every 250ms).
-/// </summary>
-public sealed class PwmGate(PoolWeightWatcher weights, TimeSpan period)
-{
-    private static readonly TimeSpan RecheckDelay = TimeSpan.FromMilliseconds(250);
-
-    private readonly long _startTimestamp = Stopwatch.GetTimestamp();
-    private readonly double _phaseOffsetMs = Random.Shared.NextDouble() * period.TotalMilliseconds;
-
-    public async Task WaitForOnWindowAsync(CancellationToken cancellationToken)
-    {
-        while (true)
-        {
-            double weight = weights.CurrentWeight;
-
-            if (weight >= 1d)
-            {
-                return;
-            }
-
-            if (weight > 0d)
-            {
-                double positionMs = (Stopwatch.GetElapsedTime(_startTimestamp).TotalMilliseconds + _phaseOffsetMs)
-                    % period.TotalMilliseconds;
-                if (positionMs < period.TotalMilliseconds * weight)
-                {
-                    return;
-                }
-
-                double untilWindowOpensMs = period.TotalMilliseconds - positionMs;
-                await Task.Delay(TimeSpan.FromMilliseconds(Math.Min(untilWindowOpensMs, RecheckDelay.TotalMilliseconds)), cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            else
-            {
-                await Task.Delay(RecheckDelay, cancellationToken).ConfigureAwait(false);
-            }
-        }
     }
 }

--- a/spikes/CanaryPolling/SampleApp/OrderHandler.cs
+++ b/spikes/CanaryPolling/SampleApp/OrderHandler.cs
@@ -1,0 +1,81 @@
+using CanaryDemo.Shared;
+using JustSaying.Messaging.MessageHandling;
+using Microsoft.Extensions.Hosting;
+
+namespace SampleApp;
+
+/// <summary>A stand-in for real message processing; counts what this pod handled.</summary>
+public sealed class OrderHandler(HandledCounter counter, TimeSpan workTime) : IHandlerAsync<CanaryOrder>
+{
+    public async Task<bool> Handle(CanaryOrder message)
+    {
+        var latency = message.PublishedAtUtc == default
+            ? TimeSpan.Zero
+            : DateTime.UtcNow - message.PublishedAtUtc;
+        counter.Record(latency);
+
+        if (workTime > TimeSpan.Zero)
+        {
+            await Task.Delay(workTime); // simulated work
+        }
+
+        return true;
+    }
+}
+
+/// <summary>
+/// Counts handled messages and buckets their end-to-end latency. A message that was
+/// mid-delivery when a receive call got cancelled isn't lost — it goes invisible until
+/// the visibility timeout (30s by default) and is redelivered — so such "casualties"
+/// show up here as handled messages with ~30s latency.
+/// </summary>
+public sealed class HandledCounter
+{
+    private static readonly TimeSpan DelayedThreshold = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan CasualtyThreshold = TimeSpan.FromSeconds(15);
+
+    private long _count;
+    private long _delayed;
+    private long _casualties;
+    private long _maxLatencyMs;
+
+    public void Record(TimeSpan latency)
+    {
+        Interlocked.Increment(ref _count);
+        if (latency >= CasualtyThreshold)
+        {
+            Interlocked.Increment(ref _casualties);
+        }
+        else if (latency >= DelayedThreshold)
+        {
+            Interlocked.Increment(ref _delayed);
+        }
+
+        long ms = (long)latency.TotalMilliseconds;
+        long seen;
+        while (ms > (seen = Interlocked.Read(ref _maxLatencyMs)))
+        {
+            Interlocked.CompareExchange(ref _maxLatencyMs, ms, seen);
+        }
+    }
+
+    public (long Count, long Casualties, long Delayed, long MaxLatencyMs) Snapshot() =>
+        (Interlocked.Read(ref _count), Interlocked.Read(ref _casualties), Interlocked.Read(ref _delayed), Interlocked.Read(ref _maxLatencyMs));
+}
+
+/// <summary>
+/// Demo-only: periodically writes machine-readable cumulative stats to stdout so the
+/// orchestrator can measure the split. A real pod would emit metrics instead.
+/// </summary>
+public sealed class StatsReporter(HandledCounter counter, string poolName, string podName) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            var (count, casualties, delayed, maxMs) = counter.Snapshot();
+            Console.WriteLine($"STAT {poolName} {podName} {count} {casualties} {delayed} {maxMs}");
+        }
+    }
+}

--- a/spikes/CanaryPolling/SampleApp/PoolWeightWatcher.cs
+++ b/spikes/CanaryPolling/SampleApp/PoolWeightWatcher.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace SampleApp;
+
+/// <summary>
+/// The pod's view of the rollout signal: a JSON file mapping pool name to weight,
+/// e.g. <c>{"primary":1.0,"canary":0.33}</c>, re-read when its timestamp changes.
+/// This stands in for however a signal reaches pods in your platform — a
+/// ConfigMap-mounted file (which Kubernetes updates in place, no restarts) fits
+/// this shape exactly, but an env-refreshed flag service works the same way.
+/// Pods only ever read; they never talk to each other.
+/// </summary>
+public sealed class PoolWeightWatcher(string weightsFile, string poolName, ILogger<PoolWeightWatcher> logger)
+{
+    private DateTime _lastWriteUtc;
+    private double _weight = 1.0;
+
+    public double CurrentWeight
+    {
+        get
+        {
+            try
+            {
+                var writeUtc = File.GetLastWriteTimeUtc(weightsFile);
+                if (writeUtc != _lastWriteUtc)
+                {
+                    var weights = JsonSerializer.Deserialize<Dictionary<string, double>>(File.ReadAllText(weightsFile));
+                    if (weights is not null && weights.TryGetValue(poolName, out double weight))
+                    {
+                        double clamped = Math.Clamp(weight, 0d, 1d);
+                        if (Math.Abs(clamped - _weight) > double.Epsilon)
+                        {
+                            logger.LogInformation("Pool '{Pool}' weight changed {Old:0.###} -> {New:0.###}", poolName, _weight, clamped);
+                        }
+
+                        _weight = clamped;
+                    }
+
+                    _lastWriteUtc = writeUtc;
+                }
+            }
+            catch (Exception ex) when (ex is IOException or JsonException)
+            {
+                // Mid-write read race or partial file: keep the previous weight and retry
+                // on the next read. Logged because a pod silently stuck on a stale weight
+                // is exactly the failure you want to be able to see.
+                logger.LogWarning(ex, "Could not read weights file '{File}'; keeping weight {Weight:0.###}", weightsFile, _weight);
+            }
+
+            return _weight;
+        }
+    }
+}

--- a/spikes/CanaryPolling/SampleApp/Program.cs
+++ b/spikes/CanaryPolling/SampleApp/Program.cs
@@ -19,16 +19,15 @@ string Required(string key) =>
 string podName = Required("POD_NAME");
 string poolName = Required("POOL_NAME");
 string queueName = Required("QUEUE_NAME");
-string weightsFile = Required("WEIGHTS_FILE");
 string region = builder.Configuration["AWS_REGION"] ?? "eu-west-1";
-var pwmPeriod = TimeSpan.FromSeconds(double.Parse(builder.Configuration["PWM_PERIOD_SECONDS"] ?? "10"));
 var receiveWait = TimeSpan.FromSeconds(double.Parse(builder.Configuration["RECEIVE_WAIT_SECONDS"] ?? "1"));
 var handlerWork = TimeSpan.FromMilliseconds(double.Parse(builder.Configuration["HANDLER_WORK_MS"] ?? "5"));
 
-// GATE_ENABLED=false turns the in-app throttle off entirely, leaving a completely
-// vanilla JustSaying consumer — used when the traffic shaping happens in a proxy
-// between the pod and SQS instead.
-bool gateEnabled = !bool.TryParse(builder.Configuration["GATE_ENABLED"], out bool ge) || ge;
+// The in-app canary gate is opt-in: it exists only if a weights file is configured.
+// With no WEIGHTS_FILE this is a completely vanilla JustSaying consumer — which is the
+// whole pod when the traffic shaping happens in a proxy between it and SQS instead.
+string weightsFile = builder.Configuration["WEIGHTS_FILE"];
+var pwmPeriod = TimeSpan.FromSeconds(double.Parse(builder.Configuration["PWM_PERIOD_SECONDS"] ?? "10"));
 
 // When SQS_ENDPOINT is set we point the SDK at floci; when it isn't, the default
 // AWS credential chain and real SQS are used, like any production service.
@@ -68,11 +67,14 @@ builder.Services
                     .WithDefaultPrefetch(5)
                     .WithDefaultMultiplexerCapacity(10);
 
-                if (gateEnabled)
+                if (weightsFile is not null)
                 {
+                    var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
                     d.WithCustomMiddleware(new GatedReceiveMiddleware(
-                        new PwmGate(sp.GetRequiredService<PoolWeightWatcher>(), pwmPeriod),
-                        sp.GetRequiredService<ILogger<JustSaying.Messaging.Middleware.Receive.DefaultReceiveMessagesMiddleware>>()));
+                        new PwmGate(
+                            new PoolWeightWatcher(weightsFile, poolName, loggerFactory.CreateLogger<PoolWeightWatcher>()),
+                            pwmPeriod),
+                        loggerFactory.CreateLogger<JustSaying.Messaging.Middleware.Receive.DefaultReceiveMessagesMiddleware>()));
                 }
             });
             sub.ForQueue<CanaryOrder>(q => q.WithQueueName(queueName));
@@ -80,7 +82,6 @@ builder.Services
     });
 
 builder.Services
-    .AddSingleton(sp => new PoolWeightWatcher(weightsFile, poolName, sp.GetRequiredService<ILogger<PoolWeightWatcher>>()))
     .AddHostedService<BusRunnerService>()
     .AddHostedService(sp => new StatsReporter(sp.GetRequiredService<HandledCounter>(), poolName, podName));
 

--- a/spikes/CanaryPolling/SampleApp/Program.cs
+++ b/spikes/CanaryPolling/SampleApp/Program.cs
@@ -25,6 +25,11 @@ var pwmPeriod = TimeSpan.FromSeconds(double.Parse(builder.Configuration["PWM_PER
 var receiveWait = TimeSpan.FromSeconds(double.Parse(builder.Configuration["RECEIVE_WAIT_SECONDS"] ?? "1"));
 var handlerWork = TimeSpan.FromMilliseconds(double.Parse(builder.Configuration["HANDLER_WORK_MS"] ?? "5"));
 
+// GATE_ENABLED=false turns the in-app throttle off entirely, leaving a completely
+// vanilla JustSaying consumer — used when the traffic shaping happens in a proxy
+// between the pod and SQS instead.
+bool gateEnabled = !bool.TryParse(builder.Configuration["GATE_ENABLED"], out bool ge) || ge;
+
 // When SQS_ENDPOINT is set we point the SDK at floci; when it isn't, the default
 // AWS credential chain and real SQS are used, like any production service.
 string sqsEndpoint = builder.Configuration["SQS_ENDPOINT"];
@@ -56,14 +61,20 @@ builder.Services
             // The canary throttle: the PWM gate holds each poll until the on-window.
             // Note the receive wait (1s) is deliberately well under the PWM period —
             // the last poll of a window lingers up to one wait into the off-window.
-            sub.WithDefaults(d => d
-                .WithDefaultReceiveMessagesWaitTime(receiveWait)
-                .WithDefaultConcurrencyLimit(8)
-                .WithDefaultPrefetch(5)
-                .WithDefaultMultiplexerCapacity(10)
-                .WithCustomMiddleware(new GatedReceiveMiddleware(
-                    new PwmGate(sp.GetRequiredService<PoolWeightWatcher>(), pwmPeriod),
-                    sp.GetRequiredService<ILogger<JustSaying.Messaging.Middleware.Receive.DefaultReceiveMessagesMiddleware>>())));
+            sub.WithDefaults(d =>
+            {
+                d.WithDefaultReceiveMessagesWaitTime(receiveWait)
+                    .WithDefaultConcurrencyLimit(8)
+                    .WithDefaultPrefetch(5)
+                    .WithDefaultMultiplexerCapacity(10);
+
+                if (gateEnabled)
+                {
+                    d.WithCustomMiddleware(new GatedReceiveMiddleware(
+                        new PwmGate(sp.GetRequiredService<PoolWeightWatcher>(), pwmPeriod),
+                        sp.GetRequiredService<ILogger<JustSaying.Messaging.Middleware.Receive.DefaultReceiveMessagesMiddleware>>()));
+                }
+            });
             sub.ForQueue<CanaryOrder>(q => q.WithQueueName(queueName));
         });
     });

--- a/spikes/CanaryPolling/SampleApp/Program.cs
+++ b/spikes/CanaryPolling/SampleApp/Program.cs
@@ -1,0 +1,76 @@
+using CanaryDemo.Shared;
+using JustSaying;
+using JustSaying.Messaging;
+using JustSaying.Messaging.MessageHandling;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using SampleApp;
+
+// One consumer "pod": a plain JustSaying subscriber plus the PWM gate throttle
+// (GatedReceiveMiddleware). Everything it knows arrives through configuration —
+// pods never talk to each other.
+
+var builder = Host.CreateApplicationBuilder(args);
+
+string Required(string key) =>
+    builder.Configuration[key] ?? throw new InvalidOperationException($"Missing required configuration '{key}'.");
+
+string podName = Required("POD_NAME");
+string poolName = Required("POOL_NAME");
+string queueName = Required("QUEUE_NAME");
+string weightsFile = Required("WEIGHTS_FILE");
+string region = builder.Configuration["AWS_REGION"] ?? "eu-west-1";
+var pwmPeriod = TimeSpan.FromSeconds(double.Parse(builder.Configuration["PWM_PERIOD_SECONDS"] ?? "10"));
+var receiveWait = TimeSpan.FromSeconds(double.Parse(builder.Configuration["RECEIVE_WAIT_SECONDS"] ?? "1"));
+var handlerWork = TimeSpan.FromMilliseconds(double.Parse(builder.Configuration["HANDLER_WORK_MS"] ?? "5"));
+
+// When SQS_ENDPOINT is set we point the SDK at floci; when it isn't, the default
+// AWS credential chain and real SQS are used, like any production service.
+string sqsEndpoint = builder.Configuration["SQS_ENDPOINT"];
+
+// stdout carries the STAT lines the orchestrator reads; send logs to stderr.
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
+builder.Logging.SetMinimumLevel(Enum.TryParse<LogLevel>(builder.Configuration["LOG_LEVEL"], out var level) ? level : LogLevel.Warning);
+
+builder.Services
+    .AddSingleton<HandledCounter>()
+    .AddSingleton<IHandlerAsync<CanaryOrder>>(sp => new OrderHandler(sp.GetRequiredService<HandledCounter>(), handlerWork))
+    .AddJustSaying((config, sp) =>
+    {
+        config.Messaging(m => m.WithRegion(region));
+        if (sqsEndpoint is not null)
+        {
+            string accountId = Required("AWS_ACCOUNT_ID");
+            config.Client(c => c.WithClientFactory(() => new FlociClientFactory(new Uri(sqsEndpoint), accountId, region)));
+        }
+
+        config.Subscriptions(sub =>
+        {
+            // Small prefetch/multiplexer matter for PWM fidelity: throttling only stops
+            // fetching, so anything already buffered in-process is still handled during
+            // the off-window. JustSaying's defaults (prefetch 10, multiplexer 100) let a
+            // pod hoard >100 messages per on-window under backlog, which flattens the
+            // duty cycle; keeping the in-process pipeline shallow bounds that carryover.
+            // The canary throttle: the PWM gate holds each poll until the on-window.
+            // Note the receive wait (1s) is deliberately well under the PWM period —
+            // the last poll of a window lingers up to one wait into the off-window.
+            sub.WithDefaults(d => d
+                .WithDefaultReceiveMessagesWaitTime(receiveWait)
+                .WithDefaultConcurrencyLimit(8)
+                .WithDefaultPrefetch(5)
+                .WithDefaultMultiplexerCapacity(10)
+                .WithCustomMiddleware(new GatedReceiveMiddleware(
+                    new PwmGate(sp.GetRequiredService<PoolWeightWatcher>(), pwmPeriod),
+                    sp.GetRequiredService<ILogger<JustSaying.Messaging.Middleware.Receive.DefaultReceiveMessagesMiddleware>>())));
+            sub.ForQueue<CanaryOrder>(q => q.WithQueueName(queueName));
+        });
+    });
+
+builder.Services
+    .AddSingleton(sp => new PoolWeightWatcher(weightsFile, poolName, sp.GetRequiredService<ILogger<PoolWeightWatcher>>()))
+    .AddHostedService<BusRunnerService>()
+    .AddHostedService(sp => new StatsReporter(sp.GetRequiredService<HandledCounter>(), poolName, podName));
+
+await builder.Build().RunAsync();

--- a/spikes/CanaryPolling/SampleApp/SampleApp.csproj
+++ b/spikes/CanaryPolling/SampleApp/SampleApp.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <Nullable>disable</Nullable>
+    <RootNamespace>SampleApp</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\CanaryDemo.Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+</Project>

--- a/spikes/CanaryPolling/Shared/CanaryDemo.Shared.csproj
+++ b/spikes/CanaryPolling/Shared/CanaryDemo.Shared.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <Nullable>disable</Nullable>
+    <RootNamespace>CanaryDemo.Shared</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JustSaying" />
+    <PackageReference Include="JustSaying.Extensions.DependencyInjection.Microsoft" />
+  </ItemGroup>
+
+</Project>

--- a/spikes/CanaryPolling/Shared/FlociClientFactory.cs
+++ b/spikes/CanaryPolling/Shared/FlociClientFactory.cs
@@ -1,0 +1,41 @@
+using Amazon;
+using Amazon.Runtime;
+using Amazon.SimpleNotificationService;
+using Amazon.SQS;
+using JustSaying.AwsTools;
+
+namespace CanaryDemo.Shared;
+
+/// <summary>
+/// Real AWS SDK clients pointed at a floci container. Floci treats a 12-digit
+/// access key id as the account id, giving each demo run isolated resources.
+/// </summary>
+public sealed class FlociClientFactory(Uri serviceUrl, string accountId, string region) : IAwsClientFactory
+{
+    private readonly AWSCredentials _credentials = new BasicAWSCredentials(accountId, "secret");
+
+    public IAmazonSimpleNotificationService GetSnsClient(RegionEndpoint regionEndpoint) =>
+        new AmazonSimpleNotificationServiceClient(_credentials, new AmazonSimpleNotificationServiceConfig
+        {
+            ServiceURL = serviceUrl.ToString(),
+            AuthenticationRegion = ResolveRegion(regionEndpoint),
+        });
+
+    public IAmazonSQS GetSqsClient(RegionEndpoint regionEndpoint) =>
+        new AmazonSQSClient(_credentials, new AmazonSQSConfig
+        {
+            ServiceURL = serviceUrl.ToString(),
+            AuthenticationRegion = ResolveRegion(regionEndpoint),
+        });
+
+    // JustSaying falls back to "unknown" when it cannot parse a region from a custom
+    // queue URL; pin those calls back to the demo's region so they hit the same
+    // floci partition.
+    private string ResolveRegion(RegionEndpoint regionEndpoint)
+    {
+        var name = regionEndpoint?.SystemName;
+        return string.IsNullOrEmpty(name) || string.Equals(name, "unknown", StringComparison.OrdinalIgnoreCase)
+            ? region
+            : name;
+    }
+}

--- a/spikes/CanaryPolling/Shared/Messages.cs
+++ b/spikes/CanaryPolling/Shared/Messages.cs
@@ -1,0 +1,11 @@
+using JustSaying.Models;
+
+namespace CanaryDemo.Shared;
+
+public sealed class CanaryOrder : Message
+{
+    public int Sequence { get; set; }
+
+    /// <summary>Stamped by the producer so consumers can measure end-to-end latency.</summary>
+    public DateTime PublishedAtUtc { get; set; }
+}

--- a/spikes/CanaryPolling/Shared/PoolWeightWatcher.cs
+++ b/spikes/CanaryPolling/Shared/PoolWeightWatcher.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
-namespace SampleApp;
+namespace CanaryDemo.Shared;
 
 /// <summary>
 /// The pod's view of the rollout signal: a JSON file mapping pool name to weight,

--- a/spikes/CanaryPolling/Shared/PwmGate.cs
+++ b/spikes/CanaryPolling/Shared/PwmGate.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics;
+
+namespace CanaryDemo.Shared;
+
+/// <summary>
+/// The PWM clock: on for <c>weight × period</c>, off for the rest, random phase per
+/// instance. Weight comes from the watched rollout signal on every check, so changes
+/// apply within 250ms; weight 1 never gates, weight 0 parks the caller (checked every
+/// 250ms). Used by both the in-app receive-middleware gate and the SQS proxy.
+/// </summary>
+public sealed class PwmGate(PoolWeightWatcher weights, TimeSpan period)
+{
+    private static readonly TimeSpan RecheckDelay = TimeSpan.FromMilliseconds(250);
+
+    private readonly long _startTimestamp = Stopwatch.GetTimestamp();
+    private readonly double _phaseOffsetMs = Random.Shared.NextDouble() * period.TotalMilliseconds;
+
+    /// <summary>Waits until the on-window; only returns when the window is open.</summary>
+    public async Task WaitForOnWindowAsync(CancellationToken cancellationToken) =>
+        await TryWaitForOnWindowAsync(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Waits until the on-window or the timeout, whichever comes first. Returns true if
+    /// the window is open; false if the timeout elapsed while still gated (the proxy
+    /// uses this to emulate an empty long poll of the request's WaitTimeSeconds).
+    /// </summary>
+    public async Task<bool> TryWaitForOnWindowAsync(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        long deadline = timeout == Timeout.InfiniteTimeSpan
+            ? long.MaxValue
+            : Stopwatch.GetTimestamp() + (long)(timeout.TotalSeconds * Stopwatch.Frequency);
+
+        while (true)
+        {
+            double weight = weights.CurrentWeight;
+
+            if (weight >= 1d)
+            {
+                return true;
+            }
+
+            TimeSpan delay;
+            if (weight > 0d)
+            {
+                double positionMs = (Stopwatch.GetElapsedTime(_startTimestamp).TotalMilliseconds + _phaseOffsetMs)
+                    % period.TotalMilliseconds;
+                if (positionMs < period.TotalMilliseconds * weight)
+                {
+                    return true;
+                }
+
+                double untilWindowOpensMs = period.TotalMilliseconds - positionMs;
+                delay = TimeSpan.FromMilliseconds(Math.Min(untilWindowOpensMs, RecheckDelay.TotalMilliseconds));
+            }
+            else
+            {
+                delay = RecheckDelay; // parked; the weight might come back
+            }
+
+            long now = Stopwatch.GetTimestamp();
+            if (now >= deadline)
+            {
+                return false;
+            }
+
+            var untilDeadline = Stopwatch.GetElapsedTime(now, deadline);
+            await Task.Delay(delay < untilDeadline ? delay : untilDeadline, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/spikes/CanaryPolling/SqsProxy/Program.cs
+++ b/spikes/CanaryPolling/SqsProxy/Program.cs
@@ -1,0 +1,184 @@
+using System.Text;
+using System.Text.Json;
+using CanaryDemo.Shared;
+using Microsoft.AspNetCore.Http.Extensions;
+
+// An SQS-API-aware forward proxy implementing the canary PWM gate at the network level,
+// so consumer pods need NO application-level throttle at all — they are completely
+// vanilla SQS clients pointed at (or transparently routed through) this proxy.
+//
+// This is a stand-in for what an Istio deployment would run in the sidecar/egress path:
+// the request classification below ("is this ReceiveMessage, what's its WaitTimeSeconds")
+// and the park-or-forward decision are exactly the logic an EnvoyFilter would host — as
+// an ext_proc gRPC processor or a WASM filter (Envoy's Lua filter can't asynchronously
+// delay, which this needs). Pool identity comes from which listener port the pod hits;
+// in Istio it would come from workload labels selecting per-Deployment filter config.
+//
+// The gate is cooperative, same as the in-app variant: a ReceiveMessage arriving in the
+// off-window is *parked* for up to its own WaitTimeSeconds (preserving long-poll
+// semantics — the pod just sees an empty poll), and forwarded if the window opens
+// mid-park. Requests are never mutated (SigV4 signatures stay valid) and never
+// cancelled (no messages stranded mid-delivery). Everything that isn't ReceiveMessage —
+// sends, deletes, queue management — passes straight through.
+//
+// Configuration (env):
+//   UPSTREAM            SQS-compatible endpoint to forward to (e.g. floci)
+//   PRIMARY_PORT        listener for primary-pool pods (weight from key "primary")
+//   CANARY_PORT         listener for canary-pool pods (weight from key "canary")
+//   WEIGHTS_FILE        the rollout signal: {"primary":1.0,"canary":0.33}
+//   PWM_PERIOD_SECONDS  PWM period (default 10)
+
+var builder = WebApplication.CreateBuilder(args);
+
+string Required(string key) =>
+    builder.Configuration[key] ?? throw new InvalidOperationException($"Missing required configuration '{key}'.");
+
+var upstream = new Uri(Required("UPSTREAM"));
+int primaryPort = int.Parse(Required("PRIMARY_PORT"));
+int canaryPort = int.Parse(Required("CANARY_PORT"));
+string weightsFile = Required("WEIGHTS_FILE");
+var pwmPeriod = TimeSpan.FromSeconds(double.Parse(builder.Configuration["PWM_PERIOD_SECONDS"] ?? "10"));
+
+builder.WebHost.UseUrls($"http://127.0.0.1:{primaryPort}", $"http://127.0.0.1:{canaryPort}");
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
+builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+var app = builder.Build();
+
+var loggerFactory = app.Services.GetRequiredService<ILoggerFactory>();
+var gates = new Dictionary<int, PwmGate>
+{
+    [primaryPort] = new(new PoolWeightWatcher(weightsFile, "primary", loggerFactory.CreateLogger<PoolWeightWatcher>()), pwmPeriod),
+    [canaryPort] = new(new PoolWeightWatcher(weightsFile, "canary", loggerFactory.CreateLogger<PoolWeightWatcher>()), pwmPeriod),
+};
+
+var http = new HttpClient(new SocketsHttpHandler { AllowAutoRedirect = false })
+{
+    BaseAddress = upstream,
+    Timeout = TimeSpan.FromSeconds(100),
+};
+
+// Hop-by-hop headers, plus ones HttpClient computes itself.
+string[] skipRequestHeaders = ["Host", "Content-Length", "Connection", "Transfer-Encoding", "Keep-Alive", "Expect"];
+
+app.MapGet("/healthz", () => "ok");
+
+app.Map("/{**path}", async context =>
+{
+    var gate = gates[context.Connection.LocalPort];
+
+    // Buffer the body: we need it to classify the request, and again to forward it.
+    byte[] body;
+    using (var buffer = new MemoryStream())
+    {
+        await context.Request.Body.CopyToAsync(buffer, context.RequestAborted);
+        body = buffer.ToArray();
+    }
+
+    // --- The canary gate: only ReceiveMessage is shaped; everything else flows.
+    if (TryClassifyReceiveMessage(context.Request, body, out int waitSeconds, out bool jsonProtocol))
+    {
+        bool windowOpen = await gate.TryWaitForOnWindowAsync(TimeSpan.FromSeconds(waitSeconds), context.RequestAborted);
+        if (!windowOpen)
+        {
+            // Emulate an empty long poll: the pod waited its WaitTimeSeconds and got
+            // nothing, exactly as if the queue were empty. It will simply poll again.
+            context.Response.StatusCode = StatusCodes.Status200OK;
+            if (jsonProtocol)
+            {
+                context.Response.ContentType = "application/x-amz-json-1.0";
+                await context.Response.WriteAsync("{}", context.RequestAborted);
+            }
+            else
+            {
+                context.Response.ContentType = "text/xml";
+                await context.Response.WriteAsync(
+                    """<?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult/><ResponseMetadata><RequestId>canary-proxy-gated</RequestId></ResponseMetadata></ReceiveMessageResponse>""",
+                    context.RequestAborted);
+            }
+
+            return;
+        }
+    }
+
+    // --- Transparent forward, bytes untouched so SigV4 signatures stay intact.
+    using var request = new HttpRequestMessage(new HttpMethod(context.Request.Method), context.Request.Path + context.Request.QueryString);
+    if (body.Length > 0 || context.Request.ContentLength > 0)
+    {
+        request.Content = new ByteArrayContent(body);
+    }
+
+    foreach (var header in context.Request.Headers)
+    {
+        if (skipRequestHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            continue;
+        }
+
+        if (!request.Headers.TryAddWithoutValidation(header.Key, (IEnumerable<string>)header.Value))
+        {
+            request.Content?.Headers.TryAddWithoutValidation(header.Key, (IEnumerable<string>)header.Value);
+        }
+    }
+
+    using var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, context.RequestAborted);
+
+    context.Response.StatusCode = (int)response.StatusCode;
+    foreach (var header in response.Headers.Concat(response.Content.Headers))
+    {
+        if (!string.Equals(header.Key, "Transfer-Encoding", StringComparison.OrdinalIgnoreCase))
+        {
+            context.Response.Headers[header.Key] = header.Value.ToArray();
+        }
+    }
+
+    await response.Content.CopyToAsync(context.Response.Body, context.RequestAborted);
+});
+
+await app.RunAsync();
+
+// Classifies a request as SQS ReceiveMessage and extracts its WaitTimeSeconds, for both
+// wire protocols the SQS SDKs use: JSON (X-Amz-Target header, JSON body) and the older
+// form-encoded Query protocol (Action=ReceiveMessage in the body).
+static bool TryClassifyReceiveMessage(HttpRequest request, byte[] body, out int waitSeconds, out bool jsonProtocol)
+{
+    waitSeconds = 0;
+    jsonProtocol = false;
+
+    if (request.Headers.TryGetValue("X-Amz-Target", out var target) &&
+        target.ToString().EndsWith(".ReceiveMessage", StringComparison.Ordinal))
+    {
+        jsonProtocol = true;
+        try
+        {
+            using var json = JsonDocument.Parse(body);
+            if (json.RootElement.TryGetProperty("WaitTimeSeconds", out var wait) && wait.TryGetInt32(out int seconds))
+            {
+                waitSeconds = seconds;
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return true;
+    }
+
+    if (string.Equals(request.ContentType?.Split(';')[0], "application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
+    {
+        var form = Encoding.UTF8.GetString(body);
+        if (form.Split('&').Contains("Action=ReceiveMessage"))
+        {
+            var wait = form.Split('&').FirstOrDefault(p => p.StartsWith("WaitTimeSeconds=", StringComparison.Ordinal));
+            if (wait is not null && int.TryParse(wait["WaitTimeSeconds=".Length..], out int seconds))
+            {
+                waitSeconds = seconds;
+            }
+
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/spikes/CanaryPolling/SqsProxy/SqsProxy.csproj
+++ b/spikes/CanaryPolling/SqsProxy/SqsProxy.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <Nullable>disable</Nullable>
+    <RootNamespace>SqsProxy</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\CanaryDemo.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/spikes/CanaryPolling/localsqssnsmessaging-longpoll-fairness.md
+++ b/spikes/CanaryPolling/localsqssnsmessaging-longpoll-fairness.md
@@ -1,0 +1,72 @@
+# Issue draft for justeattakeaway/LocalSqsSnsMessaging
+
+**Title:** Server mode: long-poll delivery is winner-takes-all when messages arrive slower than the wait time (real SQS is roughly uniform)
+
+---
+
+While spiking a canary rollout mechanism for JustSaying (splitting traffic between two pools of consumers on one queue by throttling their polling), I got results against floci that didn't reproduce on real SQS. The functional behaviour is spot on, but the _distribution_ behaviour — which waiting receiver gets the next message — diverges in a way that can mislead any test involving competing consumers.
+
+## Repro
+
+4 identical consumers long polling one standard queue with `WaitTimeSeconds = 1`, and a producer sending one message every 2 seconds — so every consumer's poll expires empty and re-parks between arrivals:
+
+```csharp
+var sqs = new AmazonSQSClient(
+    new BasicAWSCredentials("123456789012", "secret"),
+    new AmazonSQSConfig { ServiceURL = "http://localhost:4566", AuthenticationRegion = "eu-west-1" });
+
+var queueUrl = (await sqs.CreateQueueAsync("fairness")).QueueUrl;
+
+var counts = new int[4];
+for (int i = 0; i < 4; i++)
+{
+    int consumer = i;
+    _ = Task.Run(async () =>
+    {
+        while (true)
+        {
+            var response = await sqs.ReceiveMessageAsync(new ReceiveMessageRequest
+            {
+                QueueUrl = queueUrl,
+                WaitTimeSeconds = 1,
+            });
+            foreach (var message in response.Messages ?? [])
+            {
+                Interlocked.Increment(ref counts[consumer]);
+                await sqs.DeleteMessageAsync(queueUrl, message.ReceiptHandle);
+            }
+        }
+    });
+}
+
+await Task.Delay(500);
+for (int i = 0; i < 30; i++)
+{
+    await sqs.SendMessageAsync(queueUrl, $"message {i}");
+    await Task.Delay(2000);
+}
+```
+
+Against `floci/floci:latest`, one consumer receives (almost) every message:
+
+```text
+consumer counts: 0, 30, 0, 0
+consumer counts: 5, 0, 0, 25   (second run — the winner can shift, but it's winner-takes-all)
+```
+
+Against real SQS (eu-west-1, same code), the spread is roughly even, consistent with SQS picking ~uniformly among whoever is parked when a message lands. The in-memory `InMemoryAwsBus` is also fair here (`6, 9, 7, 8`), so this looks specific to the server path.
+
+The trigger seems to be the arrival gap exceeding the wait time. Bump the wait to `5` (so polls span the gaps) and the server is fair again: `7, 6, 11, 6`. It's exactly the idle-queue case — sparse traffic, all workers parked — where it bites.
+
+## What I think is going on
+
+In `InternalSqsClient.ReceiveMessageAsync` (standard queue path), every waiting receive awaits `WaitToReadAsync` on the queue's shared `Messages` channel, and the woken waiters race `TryRead`. Two things fall out of that:
+
+- The race winner is decided by continuation scheduling, not anything random. In-process there's enough jitter (and the winner re-parks last, which rotates the order), but over HTTP the timeout/re-park cycle appears to settle into a stable order, so the same waiter keeps winning.
+- A woken waiter that loses the race returns an **empty response immediately**, even with most of its `WaitTimeSeconds` remaining — real SQS would hold the poll open until a message arrives or the wait elapses. That's arguably its own divergence, and it feeds the first one (losers re-park constantly).
+
+## Why it matters
+
+Anything measuring how work spreads across competing consumers — canary traffic splits, work-stealing balance, autoscaling experiments — passes functionally but gives the wrong answer. In my case a throttled consumer pool measured 0% share against floci and 20% against real SQS with identical code, which sent me down a rabbit hole before I twigged it was the emulator.
+
+My instinct for a fix would be an explicit collection of parked receive requests, with delivery handing the message to one picked at random, and losers continuing to wait out their remaining `WaitTimeSeconds` — that would sort both divergences in one go. Is that a direction you'd be happy with? Happy to have a go at a PR.


### PR DESCRIPTION
This adds a runnable spike (under `spikes/`, nothing shipped) exploring canary rollouts for SQS consumers: two pools of JustSaying pods share one queue and split traffic by a target percentage using only app-level polling control — no infrastructure routing, no pod coordination.

The mechanism is a PWM gate in the receive middleware (`GatedReceiveMiddleware`): during the on-window the pod polls exactly like an unthrottled one, during the off-window the next poll simply isn't started, so nothing is ever cancelled and no message is stranded mid-delivery. The demo spawns pods as separate OS processes driven by a watched weights file, and validates the split against floci and real AWS SQS across backlog, steady and idle regimes (20% target measured at 19-24%, zero casualties, full write-up in the README).

Came out of #2287 — the pause-signal + cancellation variant was A/B'd against this on real AWS and lost (2.8-4.4% of messages stranded until visibility timeout under churn); the results are recorded in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
